### PR TITLE
Read file as bytes

### DIFF
--- a/vint/ast/parsing.py
+++ b/vint/ast/parsing.py
@@ -28,5 +28,5 @@ class Parser(object):
 
     def parse_file(self, file_path):
         """ Parse vim script file and return the AST. """
-        with file_path.open() as f:
+        with file_path.open('rb') as f:
             return self.parse(f.read())


### PR DESCRIPTION
Windows でマルチバイト文字(utf-8)を含んだファイルで実行すると cp932 と間違って開いてエラーになっていたので直しました。
