### PR TITLE
Fix dangerous commands validation

### DIFF
--- a/vint/linting/policy/prohibit_command_with_unintended_side_effect.py
+++ b/vint/linting/policy/prohibit_command_with_unintended_side_effect.py
@@ -5,14 +5,10 @@ from vint.ast.node_type import NodeType
 from vint.linting.policy_loader import register_policy
 
 
-PROHIBITED_COMMAND_PATTERNS = ('s/',
-                               'su/',
-                               'substitute/',
+PROHIBITED_COMMAND_PATTERNS = ('substitute',
                                '&',
                                '~',
-                               'sno/',
                                'snomagic',
-                               'sm/',
                                'smagic')
 
 
@@ -36,8 +32,8 @@ class ProhibitCommandWithUnintendedSideEffect(AbstractPolicy):
         This policy prohibit using `:s[ubstitute]` family.
         """
 
-        command = node['str']
-        is_prohibited_command = any(pattern in command
+        command = node['ea']['cmd']['name']
+        is_prohibited_command = any(pattern == command
                                     for pattern in PROHIBITED_COMMAND_PATTERNS)
 
         return not is_prohibited_command


### PR DESCRIPTION
コマンド内に s/ があると誤爆していたので修正してみました。
自分のvimrcだと以下のコマンド等々で引っかかってます。

```
runtime macros/matchit.vim
```

修正後に簡単に動作確認してみた結果です。

```
$ cat s.vim 
s///
su///
sub///
subs///
subst///
substi///
substit///
substitu///
substitut///
substitute///
&
&&
~
~&
~g&
sno
snom
snoma
snomag
snomagi
snomagic
sm
sma
smag
smagi
smagic
a s/
a &
a ~
$ vint s.vim
s.vim:1:1: Avoid commands that rely on user settings (see Google VimScript Style Guide (Fragile))
s.vim:1:1: Do not use the command that has unintended side effect (see Google VimScript Style Guide (Dangerous))
s.vim:2:1: Avoid commands that rely on user settings (see Google VimScript Style Guide (Fragile))
s.vim:2:1: Do not use the command that has unintended side effect (see Google VimScript Style Guide (Dangerous))
s.vim:3:1: Do not use the command that has unintended side effect (see Google VimScript Style Guide (Dangerous))
s.vim:4:1: Avoid commands that rely on user settings (see Google VimScript Style Guide (Fragile))
s.vim:4:1: Do not use the command that has unintended side effect (see Google VimScript Style Guide (Dangerous))
s.vim:5:1: Do not use the command that has unintended side effect (see Google VimScript Style Guide (Dangerous))
s.vim:6:1: Do not use the command that has unintended side effect (see Google VimScript Style Guide (Dangerous))
s.vim:7:1: Do not use the command that has unintended side effect (see Google VimScript Style Guide (Dangerous))
s.vim:8:1: Do not use the command that has unintended side effect (see Google VimScript Style Guide (Dangerous))
s.vim:9:1: Do not use the command that has unintended side effect (see Google VimScript Style Guide (Dangerous))
s.vim:10:1: Avoid commands that rely on user settings (see Google VimScript Style Guide (Fragile))
s.vim:10:1: Do not use the command that has unintended side effect (see Google VimScript Style Guide (Dangerous))
s.vim:11:1: Do not use the command that has unintended side effect (see Google VimScript Style Guide (Dangerous))
s.vim:12:1: Do not use the command that has unintended side effect (see Google VimScript Style Guide (Dangerous))
s.vim:13:1: Do not use the command that has unintended side effect (see Google VimScript Style Guide (Dangerous))
s.vim:14:1: Do not use the command that has unintended side effect (see Google VimScript Style Guide (Dangerous))
s.vim:15:1: Do not use the command that has unintended side effect (see Google VimScript Style Guide (Dangerous))
s.vim:16:1: Do not use the command that has unintended side effect (see Google VimScript Style Guide (Dangerous))
s.vim:17:1: Do not use the command that has unintended side effect (see Google VimScript Style Guide (Dangerous))
s.vim:18:1: Do not use the command that has unintended side effect (see Google VimScript Style Guide (Dangerous))
s.vim:19:1: Do not use the command that has unintended side effect (see Google VimScript Style Guide (Dangerous))
s.vim:20:1: Do not use the command that has unintended side effect (see Google VimScript Style Guide (Dangerous))
s.vim:21:1: Do not use the command that has unintended side effect (see Google VimScript Style Guide (Dangerous))
s.vim:22:1: Do not use the command that has unintended side effect (see Google VimScript Style Guide (Dangerous))
s.vim:23:1: Do not use the command that has unintended side effect (see Google VimScript Style Guide (Dangerous))
s.vim:24:1: Do not use the command that has unintended side effect (see Google VimScript Style Guide (Dangerous))
s.vim:25:1: Do not use the command that has unintended side effect (see Google VimScript Style Guide (Dangerous))
s.vim:26:1: Do not use the command that has unintended side effect (see Google VimScript Style Guide (Dangerous))
s.vim:27:1: Avoid commands that rely on user settings (see Google VimScript Style Guide (Fragile))
$ 
```
