### PR TITLE
Make invalid severity tolerance

### DIFF
--- a/vint/linting/config/config_file_source.py
+++ b/vint/linting/config/config_file_source.py
@@ -1,4 +1,5 @@
 import yaml
+import logging
 from vint.linting.config.config_source import ConfigSource
 from vint.linting.level import Level
 
@@ -19,9 +20,27 @@ class ConfigFileSource(ConfigSource):
         if 'cmdargs' in yaml_dict:
             cmdargs_dict = yaml_dict['cmdargs']
             if 'severity' in cmdargs_dict:
-                cmdargs_dict['severity'] = Level[cmdargs_dict['severity'].upper()]
+                severity_name = cmdargs_dict['severity'].upper()
+                severity = getattr(Level, severity_name, None)
+
+                if not severity:
+                    self._warn_invalid_severity(severity_name)
+                    return yaml_dict
+
+                cmdargs_dict['severity'] = severity
 
         return yaml_dict
+
+
+    def _warn_invalid_severity(self, severity_name):
+        possible_severities = ', '.join([possible_severity.name.lower()
+                                         for possible_severity
+                                         in list(Level)])
+
+        logging.warning(('Severity `{severity_name}` is invalid. ' +
+                         'Possible: {possible_severities}').format(
+                             severity_name=severity_name,
+                             possible_severities=possible_severities))
 
 
     def get_file_path(self, env):


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "bin/vint", line 25, in <module>
    vint.main()
  File "/Users/####/Development/vint/vint/__init__.py", line 20, in main
    config_dict = _build_config_dict(env)
  File "/Users/####/Development/vint/vint/__init__.py", line 48, in _build_config_dict
    ConfigGlobalSource(env),
  File "/Users/####/Development/vint/vint/linting/config/config_file_source.py", line 12, in __init__
    self._config_dict = self.convert_config_dict(yaml.load(file_obj))
  File "/Users/####/Development/vint/vint/linting/config/config_file_source.py", line 22, in convert_config_dict
    cmdargs_dict['severity'] = Level[cmdargs_dict['severity'].upper()]
```
