### PR TITLE
Add test fot dangerous commands

### DIFF
--- a/test/fixture/policy/prohibit_command_with_unintended_side_effect_invalid.vim
+++ b/test/fixture/policy/prohibit_command_with_unintended_side_effect_invalid.vim
@@ -1,11 +1,13 @@
 s/foo/bar/
-su/foo/bar/
+substi/foo/bar/
 substitute/foo/bar/
 %substitute/foo/bar/
 '<,'>substitute/foo/bar/
 &
 ~
 sno/foo/bar/
+snomag/foo/bar/
 snomagic/foo/bar/
 sm/foo/bar/
+smag/foo/bar/
 smagic/foo/bar/

--- a/test/fixture/policy/prohibit_command_with_unintended_side_effect_valid.vim
+++ b/test/fixture/policy/prohibit_command_with_unintended_side_effect_valid.vim
@@ -1,1 +1,3 @@
 match MyGroup 'substitute'
+runtime macros/matchit.vim
+123

--- a/test/integration/vint/linting/policy/test_prohibit_command_with_unintented_side_effect.py
+++ b/test/integration/vint/linting/policy/test_prohibit_command_with_unintented_side_effect.py
@@ -28,7 +28,7 @@ class TestProhibitCommandWithUnintendedSideEffect(PolicyAssertion, unittest.Test
 
     def test_get_violation_if_found_with_invalid_file(self):
         expected_violations = [self._create_violation_by_line_number(line_number)
-                               for line_number in range(1, 12)]
+                               for line_number in range(1, 14)]
 
         # Offset range token length
         expected_violations[3]['position']['column'] = 2


### PR DESCRIPTION
以前修正した件、テスト書いてみました。
invalidの方は、コマンド名を全パターン網羅させると数が多くなるので、最短、中央、最長の3パターンにしてます。
あと、 caa11777b04dc5c233b84272b64ceb6811af8098 についてもついでに追加しました。
