### PR TITLE
Disable ProhibitUnusedVariable

### DIFF
--- a/vint/asset/default_config.yaml
+++ b/vint/asset/default_config.yaml
@@ -2,3 +2,8 @@ cmdargs:
   verbose: no
   severity: warning
   error-limit: 50
+
+policies:
+  # Experimental
+  ProhibitUnusedVariable:
+    enabled: no


### PR DESCRIPTION
Now, the policy `ProhibitUnusedVariable` have many false-positives of `autocmd` and `map` family.
So, we should disable temporary ProhibitUnusedVariable (until #104 are fixed).