### PR TITLE
Allow autoload functions omit an explicit scope

### DIFF
--- a/test/asserting/policy.py
+++ b/test/asserting/policy.py
@@ -47,16 +47,19 @@ class PolicyAssertion(unittest.TestCase):
             return self._config_dict
 
 
-    def assertFoundNoViolations(self, path, Policy):
-        self.assertFoundViolationsEqual(path, Policy, [])
+    def assertFoundNoViolations(self, path, Policy, policy_options=None):
+        self.assertFoundViolationsEqual(path, Policy, [], policy_options)
 
 
-    def assertFoundViolationsEqual(self, path, Policy, expected_violations):
+    def assertFoundViolationsEqual(self, path, Policy, expected_violations, policy_options=None):
         policy_to_test = Policy()
         policy_name = Policy.__name__
 
         policy_set = PolicyAssertion.StubPolicySet(policy_to_test)
         config = PolicyAssertion.StubConfigContainer(policy_name)
+
+        if policy_options is not None:
+            config.get_config_dict()['policies'][policy_name].update(policy_options)
 
         linter = Linter(policy_set, config.get_config_dict())
         violations = linter.lint_file(path)

--- a/test/asserting/policy.py
+++ b/test/asserting/policy.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from pprint import pprint
 from compat.itertools import zip_longest
 from vint.linting.linter import Linter
+from vint.linting.config.config_default_source import ConfigDefaultSource
 
 
 class PolicyAssertion(unittest.TestCase):
@@ -22,11 +23,18 @@ class PolicyAssertion(unittest.TestCase):
     class StubConfigContainer(object):
         def __init__(self, policy_names_to_enable):
 
-            policy_enabling_map = dict((policy_name, {'enabled': True})
-                                       for policy_name in policy_names_to_enable)
+            default_config_dict = ConfigDefaultSource(None).get_config_dict()
+            policy_options = default_config_dict.get('policies', {})
+
+            for policy, options in policy_options.items():
+                options['enabled'] = False
+
+            for policy in policy_names_to_enable:
+                options = policy_options.setdefault(policy, {})
+                options['enabled'] = True
 
             self._config_dict = {
-                'policies': policy_enabling_map
+                'policies': policy_options,
             }
 
 

--- a/test/fixture/policy/prohibit_implicit_scope_variable_invalid.vim
+++ b/test/fixture/policy/prohibit_implicit_scope_variable_invalid.vim
@@ -11,3 +11,9 @@ function! ImplicitGlobalFunc(param)
     " Make fix missing a: easy
     echo param
 endfunction
+call ImplicitGlobalFunc(0)
+
+function! autoload#ImplicitGlobalAutoloadFunc(param)
+    echo autoload#AnotherImplicitGlobalAutoloadFunc(param)
+endfunction
+call autoload#ImplicitGlobalAutoloadFunc(1)

--- a/test/fixture/policy/prohibit_implicit_scope_variable_valid.vim
+++ b/test/fixture/policy/prohibit_implicit_scope_variable_valid.vim
@@ -34,6 +34,10 @@ function! s:ScriptLocalFunc()
 endfunction
 call s:ScriptLocalFunc()
 
+function! g:autoload#AutoloadFunc()
+endfunction
+call g:autoload#AutoloadFunc()
+
 " We can call buffer/window/tab local function references
 call b:BufferLocalFunc()
 call w:WindowLocalFunc()

--- a/test/integration/vint/linting/policy/test_prohibit_implicit_scope_variable.py
+++ b/test/integration/vint/linting/policy/test_prohibit_implicit_scope_variable.py
@@ -33,11 +33,33 @@ class TestProhibitImplicitScopeVariable(PolicyAssertion, unittest.TestCase):
             self.create_violation(8, 5),
             self.create_violation(10, 11),
             self.create_violation(12, 10),
+            self.create_violation(14, 6),
+            self.create_violation(16, 11),
+            self.create_violation(17, 10),
+            self.create_violation(17, 53),
+            self.create_violation(19, 6),
         ]
 
         self.assertFoundViolationsEqual(PATH_INVALID_VIM_SCRIPT,
                                         ProhibitImplicitScopeVariable,
                                         expected_violations)
+
+
+    def test_get_violation_if_found_when_autoloads_are_suppressed(self):
+        expected_violations = [
+            self.create_violation(2, 5),
+            self.create_violation(4, 10),
+            self.create_violation(8, 5),
+            self.create_violation(10, 11),
+            self.create_violation(12, 10),
+            self.create_violation(14, 6),
+            self.create_violation(17, 53),
+        ]
+
+        self.assertFoundViolationsEqual(PATH_INVALID_VIM_SCRIPT,
+                                        ProhibitImplicitScopeVariable,
+                                        expected_violations,
+                                        {'suppress_autoload': True})
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit/vint/linting/policy/test_abstract_policy.py
+++ b/test/unit/vint/linting/policy/test_abstract_policy.py
@@ -42,6 +42,33 @@ class TestAbstractPolicy(unittest.TestCase):
             policy.create_violation_report(node, env),
             expected_violation)
 
+    def test_get_policy_options(self):
+        policy = ConcretePolicy()
+
+        expected_options = {}
+        lint_context = {
+            'config': {},
+        }
+        self.assertEqual(
+            policy.get_policy_options(lint_context),
+            expected_options)
+
+        expected_options = {}
+        lint_context = {
+            'config': {'policies': {}},
+        }
+        self.assertEqual(
+            policy.get_policy_options(lint_context),
+            expected_options)
+
+        expected_options = {'someoption': True}
+        lint_context = {
+            'config': {'policies': {'ConcretePolicy': expected_options}},
+        }
+        self.assertEqual(
+            policy.get_policy_options(lint_context),
+            expected_options)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/vint/asset/default_config.yaml
+++ b/vint/asset/default_config.yaml
@@ -4,6 +4,10 @@ cmdargs:
   error-limit: 50
 
 policies:
+  ProhibitImplicitScopeVariable:
+    enabled: yes
+    suppress_autoload: no
+
   # Experimental
   ProhibitUnusedVariable:
     enabled: no

--- a/vint/ast/plugin/scope_plugin/__init__.py
+++ b/vint/ast/plugin/scope_plugin/__init__.py
@@ -12,6 +12,9 @@ from vint.ast.plugin.scope_plugin.scope_detector import (
     get_explicity_of_scope_visibility as _get_explicity_of_scope_visibility,
     normalize_variable_name as _normalize_variable_name,
 )
+from vint.ast.plugin.scope_plugin.identifier_classifier import (
+    is_autoload_identifier as _is_autoload_identifier,
+)
 
 
 # Expose to out of ScopePlugin
@@ -43,6 +46,10 @@ class ScopePlugin(object):
     def is_unused_declarative_identifier(self, node):
         return _is_declarative_identifier(node) \
             and not _is_referenced_declarative_identifier(node)
+
+
+    def is_autoload_identifier(self, node):
+        return _is_autoload_identifier(node)
 
 
     def get_objective_scope_visibility(self, node):

--- a/vint/linting/linter.py
+++ b/vint/linting/linter.py
@@ -116,6 +116,7 @@ class Linter(object):
             'root_node': root_ast,
             'stack_trace': [],
             'plugins': self._plugins,
+            'config': self._config.get_config_dict(),
         }
 
         traverse(root_ast,

--- a/vint/linting/policy/abstract_policy.py
+++ b/vint/linting/policy/abstract_policy.py
@@ -39,3 +39,9 @@ class AbstractPolicy(object):
             return None
 
         return self.create_violation_report(node, lint_context)
+
+
+    def get_policy_option(self, config_dict, name, default=None):
+        policy_section = config_dict.get('policies', {})
+        policy_options = policy_section.get(self.name, {})
+        return policy_options.get(name, default)

--- a/vint/linting/policy/abstract_policy.py
+++ b/vint/linting/policy/abstract_policy.py
@@ -41,7 +41,6 @@ class AbstractPolicy(object):
         return self.create_violation_report(node, lint_context)
 
 
-    def get_policy_option(self, config_dict, name, default=None):
-        policy_section = config_dict.get('policies', {})
-        policy_options = policy_section.get(self.name, {})
-        return policy_options.get(name, default)
+    def get_policy_options(self, lint_context):
+        policy_section = lint_context['config'].get('policies', {})
+        return policy_section.get(self.name, {})

--- a/vint/linting/policy/prohibit_implicit_scope_variable.py
+++ b/vint/linting/policy/prohibit_implicit_scope_variable.py
@@ -20,15 +20,12 @@ class ProhibitImplicitScopeVariable(AbstractPolicy):
     def is_valid(self, identifier, lint_context):
         """ Whether the identifier has a scope prefix. """
 
-        linter_config = lint_context['config']
         scope_plugin = lint_context['plugins']['scope']
         explicity = scope_plugin.get_explicity_of_scope_visibility(identifier)
         is_autoload = scope_plugin.is_autoload_identifier(identifier)
 
-        try:
-            suppress_autoload = linter_config['policies'][self.name]['suppress_autoload']
-        except KeyError:
-            suppress_autoload = False
+        config_dict = lint_context['config']
+        suppress_autoload = self.get_policy_option(config_dict, 'suppress_autoload', False)
 
         is_valid = (explicity is not ExplicityOfScopeVisibility.IMPLICIT or
                     is_autoload and suppress_autoload)

--- a/vint/linting/policy/prohibit_implicit_scope_variable.py
+++ b/vint/linting/policy/prohibit_implicit_scope_variable.py
@@ -9,7 +9,7 @@ from vint.ast.plugin.scope_plugin import ExplicityOfScopeVisibility
 class ProhibitImplicitScopeVariable(AbstractPolicy):
     def __init__(self):
         super(ProhibitImplicitScopeVariable, self).__init__()
-        self.reference = 'Anti-pattern of vimrc (Scope of variable)'
+        self.reference = 'Anti-pattern of vimrc (Scope of identifier)'
         self.level = Level.STYLE_PROBLEM
 
 
@@ -20,12 +20,23 @@ class ProhibitImplicitScopeVariable(AbstractPolicy):
     def is_valid(self, identifier, lint_context):
         """ Whether the identifier has a scope prefix. """
 
+        linter_config = lint_context['config']
         scope_plugin = lint_context['plugins']['scope']
         explicity = scope_plugin.get_explicity_of_scope_visibility(identifier)
+        is_autoload = scope_plugin.is_autoload_identifier(identifier)
 
-        self._make_description(identifier, scope_plugin)
+        try:
+            suppress_autoload = linter_config['policies'][self.name]['suppress_autoload']
+        except KeyError:
+            suppress_autoload = False
 
-        return explicity is not ExplicityOfScopeVisibility.IMPLICIT
+        is_valid = (explicity is not ExplicityOfScopeVisibility.IMPLICIT or
+                    is_autoload and suppress_autoload)
+
+        if not is_valid:
+            self._make_description(identifier, scope_plugin)
+
+        return is_valid
 
 
     def _make_description(self, identifier, scope_plugin):

--- a/vint/linting/policy/prohibit_implicit_scope_variable.py
+++ b/vint/linting/policy/prohibit_implicit_scope_variable.py
@@ -24,8 +24,8 @@ class ProhibitImplicitScopeVariable(AbstractPolicy):
         explicity = scope_plugin.get_explicity_of_scope_visibility(identifier)
         is_autoload = scope_plugin.is_autoload_identifier(identifier)
 
-        config_dict = lint_context['config']
-        suppress_autoload = self.get_policy_option(config_dict, 'suppress_autoload', False)
+        policy_options = self.get_policy_options(lint_context)
+        suppress_autoload = policy_options['suppress_autoload']
 
         is_valid = (explicity is not ExplicityOfScopeVisibility.IMPLICIT or
                     is_autoload and suppress_autoload)


### PR DESCRIPTION
Autoload functions always have the global scope visibility and are
easily distinguishable so let them omit an explicit scope.

Also update the ProhibitImplicitScopeVariable policy reference string
since it also applies to functions.