### PR TITLE
Support --format option

### DIFF
--- a/vint/linting/cli.py
+++ b/vint/linting/cli.py
@@ -74,6 +74,7 @@ class CLI(object):
         parser.add_argument('-c', '--color', action='store_true', help='colorize output when possible')
         parser.add_argument('-j', '--json', action='store_true', help='output json style')
         parser.add_argument('-t', '--stat', action='store_true', help='output statistic info')
+        parser.add_argument('-f', '--format', help='set output format')
         parser.add_argument('files', nargs='*', help='file or directory path to lint')
 
         return parser

--- a/vint/linting/config/config_cmdargs_source.py
+++ b/vint/linting/config/config_cmdargs_source.py
@@ -20,6 +20,7 @@ class ConfigCmdargsSource(ConfigSource):
         config_dict = self._normalize_verbose(env, config_dict)
         config_dict = self._normalize_severity(env, config_dict)
         config_dict = self._normalize_max_violations(env, config_dict)
+        config_dict = self._normalize_format(env, config_dict)
 
         return config_dict
 
@@ -52,6 +53,10 @@ class ConfigCmdargsSource(ConfigSource):
 
     def _normalize_max_violations(self, env, config_dict):
         return self._pass_config_by_key('max-violations', env, config_dict)
+
+
+    def _normalize_format(self, env, config_dict):
+        return self._pass_config_by_key('format', env, config_dict)
 
 
     def _normalize_severity(self, env, config_dict):

--- a/vint/linting/formatter/formatter.py
+++ b/vint/linting/formatter/formatter.py
@@ -23,12 +23,12 @@ class Formatter(object):
         else:
             cmdargs = {}
 
-        if 'format' in cmdargs:
+        if cmdargs['format']:
             self._format = cmdargs['format']
         else:
             self._format = DEFAULT_FORMAT
 
-        if 'color' in cmdargs:
+        if cmdargs['color']:
             self._should_be_colorized = cmdargs['color']
         else:
             self._should_be_colorized = False

--- a/vint/linting/formatter/formatter.py
+++ b/vint/linting/formatter/formatter.py
@@ -23,12 +23,12 @@ class Formatter(object):
         else:
             cmdargs = {}
 
-        if cmdargs['format']:
+        if 'format' in cmdargs and cmdargs['format'] is not None:
             self._format = cmdargs['format']
         else:
             self._format = DEFAULT_FORMAT
 
-        if cmdargs['color']:
+        if 'color' in cmdargs and cmdargs['color'] is not None:
             self._should_be_colorized = cmdargs['color']
         else:
             self._should_be_colorized = False


### PR DESCRIPTION
Related: #131 

### Available template variables

- `file_path`
- `file_name`
- `line_number`
- `column_number`
- `severity`
- `description`
- `policy_name`
- `reference`

### Example

```shell
vint --format '{file_path}:{line_number}:{column_number}: {severity}: {description} (see {reference})'
```