### PR TITLE
Fix invalid 'implicit scope' report on global or autoload function

### DIFF
--- a/test/fixture/policy/prohibit_implicit_scope_variable_invalid.vim
+++ b/test/fixture/policy/prohibit_implicit_scope_variable_invalid.vim
@@ -17,3 +17,7 @@ function! autoload#ImplicitGlobalAutoloadFunc(param)
     echo autoload#AnotherImplicitGlobalAutoloadFunc(param)
 endfunction
 call autoload#ImplicitGlobalAutoloadFunc(1)
+
+" implicit global variable 'i'
+for i in [1, 2, 3]
+endfor

--- a/test/fixture/policy/prohibit_implicit_scope_variable_invalid.vim
+++ b/test/fixture/policy/prohibit_implicit_scope_variable_invalid.vim
@@ -8,7 +8,7 @@ redir END
 let count = 110
 
 function! ImplicitGlobalFunc(param)
-    " Make fix missing a: easy
+    " Make it easy to fix missing a:
     echo param
 endfunction
 call ImplicitGlobalFunc(0)

--- a/test/fixture/policy/prohibit_implicit_scope_variable_invalid.vim
+++ b/test/fixture/policy/prohibit_implicit_scope_variable_invalid.vim
@@ -11,13 +11,7 @@ function! ImplicitGlobalFunc(param)
     " Make it easy to fix missing a:
     echo param
 endfunction
-call ImplicitGlobalFunc(0)
 
-function! autoload#ImplicitGlobalAutoloadFunc(param)
-    echo autoload#AnotherImplicitGlobalAutoloadFunc(param)
-endfunction
-call autoload#ImplicitGlobalAutoloadFunc(1)
-
-" implicit global variable 'i'
+" Implicit global variable 'i'
 for i in [1, 2, 3]
 endfor

--- a/test/fixture/policy/prohibit_implicit_scope_variable_valid.vim
+++ b/test/fixture/policy/prohibit_implicit_scope_variable_valid.vim
@@ -60,3 +60,12 @@ echo b:
 echo w:
 echo t:
 echo v:
+
+" Allow to omit g: from function names (#136)
+function! ImplicitGlobalFunc()
+endfunction
+call ImplicitGlobalFunc()
+
+function! autoload#ImplicitGlobalAutoloadFunc()
+endfunction
+call autoload#ImplicitGlobalAutoloadFunc()

--- a/test/integration/vint/linting/policy/test_prohibit_implicit_scope_variable.py
+++ b/test/integration/vint/linting/policy/test_prohibit_implicit_scope_variable.py
@@ -33,6 +33,7 @@ class TestProhibitImplicitScopeVariable(PolicyAssertion, unittest.TestCase):
             self.create_violation(8, 5),
             self.create_violation(12, 10),
             self.create_violation(17, 53),
+            self.create_violation(22, 5),
         ]
 
         self.assertFoundViolationsEqual(PATH_INVALID_VIM_SCRIPT,
@@ -47,6 +48,7 @@ class TestProhibitImplicitScopeVariable(PolicyAssertion, unittest.TestCase):
             self.create_violation(8, 5),
             self.create_violation(12, 10),
             self.create_violation(17, 53),
+            self.create_violation(22, 5),
         ]
 
         self.assertFoundViolationsEqual(PATH_INVALID_VIM_SCRIPT,

--- a/test/integration/vint/linting/policy/test_prohibit_implicit_scope_variable.py
+++ b/test/integration/vint/linting/policy/test_prohibit_implicit_scope_variable.py
@@ -32,8 +32,7 @@ class TestProhibitImplicitScopeVariable(PolicyAssertion, unittest.TestCase):
             self.create_violation(4, 10),
             self.create_violation(8, 5),
             self.create_violation(12, 10),
-            self.create_violation(17, 53),
-            self.create_violation(22, 5),
+            self.create_violation(16, 5),
         ]
 
         self.assertFoundViolationsEqual(PATH_INVALID_VIM_SCRIPT,
@@ -47,8 +46,7 @@ class TestProhibitImplicitScopeVariable(PolicyAssertion, unittest.TestCase):
             self.create_violation(4, 10),
             self.create_violation(8, 5),
             self.create_violation(12, 10),
-            self.create_violation(17, 53),
-            self.create_violation(22, 5),
+            self.create_violation(16, 5),
         ]
 
         self.assertFoundViolationsEqual(PATH_INVALID_VIM_SCRIPT,

--- a/test/integration/vint/linting/policy/test_prohibit_implicit_scope_variable.py
+++ b/test/integration/vint/linting/policy/test_prohibit_implicit_scope_variable.py
@@ -31,13 +31,8 @@ class TestProhibitImplicitScopeVariable(PolicyAssertion, unittest.TestCase):
             self.create_violation(2, 5),
             self.create_violation(4, 10),
             self.create_violation(8, 5),
-            self.create_violation(10, 11),
             self.create_violation(12, 10),
-            self.create_violation(14, 6),
-            self.create_violation(16, 11),
-            self.create_violation(17, 10),
             self.create_violation(17, 53),
-            self.create_violation(19, 6),
         ]
 
         self.assertFoundViolationsEqual(PATH_INVALID_VIM_SCRIPT,
@@ -50,9 +45,7 @@ class TestProhibitImplicitScopeVariable(PolicyAssertion, unittest.TestCase):
             self.create_violation(2, 5),
             self.create_violation(4, 10),
             self.create_violation(8, 5),
-            self.create_violation(10, 11),
             self.create_violation(12, 10),
-            self.create_violation(14, 6),
             self.create_violation(17, 53),
         ]
 

--- a/vint/ast/plugin/scope_plugin/__init__.py
+++ b/vint/ast/plugin/scope_plugin/__init__.py
@@ -14,6 +14,7 @@ from vint.ast.plugin.scope_plugin.scope_detector import (
 )
 from vint.ast.plugin.scope_plugin.identifier_classifier import (
     is_autoload_identifier as _is_autoload_identifier,
+    is_function_identifier as _is_function_identifier,
 )
 
 
@@ -51,6 +52,9 @@ class ScopePlugin(object):
     def is_autoload_identifier(self, node):
         return _is_autoload_identifier(node)
 
+
+    def is_function_identifier(self, node):
+        return _is_function_identifier(node)
 
     def get_objective_scope_visibility(self, node):
         link_registry = self._get_link_registry()

--- a/vint/linting/policy/prohibit_implicit_scope_variable.py
+++ b/vint/linting/policy/prohibit_implicit_scope_variable.py
@@ -27,7 +27,8 @@ class ProhibitImplicitScopeVariable(AbstractPolicy):
         policy_options = self.get_policy_options(lint_context)
         suppress_autoload = policy_options['suppress_autoload']
 
-        is_valid = (explicity is not ExplicityOfScopeVisibility.IMPLICIT or
+        is_valid = scope_plugin.is_function_identifier(identifier) or (
+                    explicity is not ExplicityOfScopeVisibility.IMPLICIT or
                     is_autoload and suppress_autoload)
 
         if not is_valid:


### PR DESCRIPTION
関数名にもスコープを明示しろという警告が出てしまう問題を修正しました．

```vim
function SomeFunc()
endfunction

function aaa#bbb()
endfunction
```

実行結果：

```
foo.vim:1:10: Make the scope explicit like `g:SomeFunc` (see Anti-pattern of vimrc (Scope of identifier))
foo.vim:4:10: Make the scope explicit like `g:aaa#bbb` (see Anti-pattern of vimrc (Scope of identifier))
```

Vim script 的には関数名に `g:` をつけるとエラーになる（昔は通ってしまっていた）はずです．

まだテストが追加できていないのでマージできる状態ではないです．
修正が正しいかどうか（Python よく知らないので変な修正になってるかも…）をレビューお願いします．問題無さそうならテスト足してみます．

直りそうな issue: #135
