### PR TITLE
Only require pathlib with Python < 3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 PyYAML == 3.11
 ansicolor == 0.2.4
-pathlib == 1.0.1
 chardet == 2.3.0

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,8 @@ def install_requires():
     if sys.version_info < (3, 4):
         # To enable Enum in Python < 3.4
         requires.append('enum34 == 1.0.4')
+        # To enable pathlib in Python < 3.4
+        requires.append('pathlib == 1.0.1')
     return requires
 
 


### PR DESCRIPTION
pathlib is a part of Python since 3.4.
See https://www.python.org/dev/peps/pep-0428/