### PR TITLE
Properly exclude all modules under test/ directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     download_url='https://github.com/Kuniwak/vint/archive/v{version}.tar.gz'.format(version=VERSION),
     install_requires=install_requires(),
     tests_require=test_requires(),
-    packages=find_packages(exclude=['dev_tool', 'test']),
+    packages=find_packages(exclude=['dev_tool', 'test*']),
     package_data={
         'vint': [
             'asset/default_config.yaml',


### PR DESCRIPTION
Without an asterisk only the topmost 'test' module is not installed.