### PR TITLE
Edit some of the output messages for grammar

### DIFF
--- a/vint/linting/policy/prohibit_abbreviation_option.py
+++ b/vint/linting/policy/prohibit_abbreviation_option.py
@@ -20,7 +20,7 @@ SetCommandFamily = {
 class ProhibitAbbreviationOption(AbstractPolicy):
     def __init__(self):
         super(ProhibitAbbreviationOption, self).__init__()
-        self.description = 'Use a full option name instead of the abbreviation'
+        self.description = 'Use the full option name instead of the abbreviation'
         self.reference = ':help option-summary'
         self.level = Level.STYLE_PROBLEM
 
@@ -76,5 +76,5 @@ class ProhibitAbbreviationOption(AbstractPolicy):
             'bad_pattern': option_name,
         }
 
-        self.description = ('Use a full option name `{good_pattern}` '
+        self.description = ('Use the full option name `{good_pattern}` '
                             'instead of `{bad_pattern}`'.format(**param))

--- a/vint/linting/policy/prohibit_autocmd_with_no_group.py
+++ b/vint/linting/policy/prohibit_autocmd_with_no_group.py
@@ -10,7 +10,7 @@ from vint.ast.dictionary.autocmd_events import AutoCmdEvents
 class ProhibitAutocmdWithNoGroup(AbstractPolicy):
     def __init__(self):
         super(ProhibitAutocmdWithNoGroup, self).__init__()
-        self.description = 'autocmd should execute in augroup or execute with a group'
+        self.description = 'autocmd should execute in an augroup or execute with a group'
         self.reference = ':help :autocmd'
         self.level = Level.WARNING
 

--- a/vint/linting/policy/prohibit_command_with_unintended_side_effect.py
+++ b/vint/linting/policy/prohibit_command_with_unintended_side_effect.py
@@ -17,7 +17,7 @@ class ProhibitCommandWithUnintendedSideEffect(AbstractPolicy):
     def __init__(self):
         super(ProhibitCommandWithUnintendedSideEffect, self).__init__()
         self.level = Level.WARNING
-        self.description = 'Do not use the command that has unintended side effect'
+        self.description = 'Do not use a command that has unintended side effects'
         self.reference = get_reference_source('DANGEROUS')
 
 

--- a/vint/linting/policy/prohibit_encoding_opt_after_scriptencoding.py
+++ b/vint/linting/policy/prohibit_encoding_opt_after_scriptencoding.py
@@ -9,7 +9,7 @@ from vint.linting.policy_registry import register_policy
 class ProhibitEncodingOptionAfterScriptEncoding(AbstractPolicy):
     def __init__(self):
         super(ProhibitEncodingOptionAfterScriptEncoding, self).__init__()
-        self.description = 'Encoding option should be place before scriptencoding'
+        self.description = 'Set encoding before setting scriptencoding'
         self.reference = ':help :scriptencoding'
         self.level = Level.WARNING
 
@@ -24,7 +24,7 @@ class ProhibitEncodingOptionAfterScriptEncoding(AbstractPolicy):
     def is_valid(self, excmd_node, lint_context):
         """ Whether the specified node is valid.
 
-        This policy prohibit encoding option after scriptencoding.
+        This policy prohibits encoding option after scriptencoding.
         """
 
         cmd_str = excmd_node['str']

--- a/vint/linting/policy/prohibit_no_abort_function.py
+++ b/vint/linting/policy/prohibit_no_abort_function.py
@@ -9,7 +9,7 @@ from vint.linting.policy_registry import register_policy
 class ProhibitNoAbortFunction(AbstractPolicy):
     def __init__(self):
         super(ProhibitNoAbortFunction, self).__init__()
-        self.description = 'Use abort attribute for functions in autoload/'
+        self.description = 'Use the abort attribute for functions in autoload'
         self.reference = get_reference_source('FUNCTIONS')
         self.level = Level.WARNING
 
@@ -21,7 +21,7 @@ class ProhibitNoAbortFunction(AbstractPolicy):
     def is_valid(self, node, lint_context):
         """ Whether the specified node is valid.
 
-        This policy prohibit that a function in autoload/ have no 'abort' or bang
+        This policy prohibits functions in autoload that have no 'abort' or bang
         """
 
         if 'autoload' not in lint_context['path'].parts:

--- a/vint/linting/policy/prohibit_set_nocompatible.py
+++ b/vint/linting/policy/prohibit_set_nocompatible.py
@@ -9,7 +9,7 @@ from vint.linting.policy_registry import register_policy
 class ProhibitSetNoCompatible(AbstractPolicy):
     def __init__(self):
         super(ProhibitSetNoCompatible, self).__init__()
-        self.description = 'Do not use nocompatible that make unexpected effects'
+        self.description = 'Do not use nocompatible which has unexpected effects'
         self.reference = ':help nocompatible'
         self.level = Level.WARNING
 


### PR DESCRIPTION
I fixed a few grammatical errors in the output messages (and a couple in the doc strings) while trying to keep the meaning as close to the original intent as possible.