### PR TITLE
Suppress ProhibitImplicitScopeVariable when --error specified

### DIFF
--- a/vint/asset/default_config.yaml
+++ b/vint/asset/default_config.yaml
@@ -5,7 +5,6 @@ cmdargs:
 
 policies:
   ProhibitImplicitScopeVariable:
-    enabled: yes
     suppress_autoload: no
 
   # Experimental

--- a/vint/linting/policy_set.py
+++ b/vint/linting/policy_set.py
@@ -49,7 +49,8 @@ class PolicySet(object):
         prior_policy_enabling_map = config_dict['policies']
 
         for policy_name, policy in prior_policy_enabling_map.items():
-            policy_enabling_map[policy_name] = policy['enabled']
+            if 'enabled' in policy:
+                policy_enabling_map[policy_name] = policy['enabled']
 
         return policy_enabling_map
 


### PR DESCRIPTION
Fix #154 