### PR TITLE
ProhibitImplicitScopeVariable: remove obsolete suppress_autoload option

### DIFF
--- a/test/integration/vint/linting/policy/test_prohibit_implicit_scope_variable.py
+++ b/test/integration/vint/linting/policy/test_prohibit_implicit_scope_variable.py
@@ -40,19 +40,5 @@ class TestProhibitImplicitScopeVariable(PolicyAssertion, unittest.TestCase):
                                         expected_violations)
 
 
-    def test_get_violation_if_found_when_autoloads_are_suppressed(self):
-        expected_violations = [
-            self.create_violation(2, 5),
-            self.create_violation(4, 10),
-            self.create_violation(8, 5),
-            self.create_violation(12, 10),
-            self.create_violation(16, 5),
-        ]
-
-        self.assertFoundViolationsEqual(PATH_INVALID_VIM_SCRIPT,
-                                        ProhibitImplicitScopeVariable,
-                                        expected_violations,
-                                        {'suppress_autoload': True})
-
 if __name__ == '__main__':
     unittest.main()

--- a/vint/asset/default_config.yaml
+++ b/vint/asset/default_config.yaml
@@ -9,9 +9,6 @@ cmdargs:
     neovim: no
 
 policies:
-  ProhibitImplicitScopeVariable:
-    suppress_autoload: no
-
   # Experimental
   ProhibitUnusedVariable:
     enabled: no

--- a/vint/linting/policy/prohibit_implicit_scope_variable.py
+++ b/vint/linting/policy/prohibit_implicit_scope_variable.py
@@ -22,14 +22,9 @@ class ProhibitImplicitScopeVariable(AbstractPolicy):
 
         scope_plugin = lint_context['plugins']['scope']
         explicity = scope_plugin.get_explicity_of_scope_visibility(identifier)
-        is_autoload = scope_plugin.is_autoload_identifier(identifier)
 
-        policy_options = self.get_policy_options(lint_context)
-        suppress_autoload = policy_options['suppress_autoload']
-
-        is_valid = scope_plugin.is_function_identifier(identifier) or (
-                    explicity is not ExplicityOfScopeVisibility.IMPLICIT or
-                    is_autoload and suppress_autoload)
+        is_valid = (scope_plugin.is_function_identifier(identifier) or
+                    explicity is not ExplicityOfScopeVisibility.IMPLICIT)
 
         if not is_valid:
             self._make_description(identifier, scope_plugin)


### PR DESCRIPTION
Initially introduced in PR#129, suppress_autoload option became obsolete
after PR#136 was merged as vint now skips scope checks for all functions
regardless of suppress_autoload option's value.

Code that handles policy options, which was also added in PR#129, is
preserved for a possible future reuse.
(It's fine, this code is covered with tests.)

Fixes issue #152.