### PR TITLE
ConfigProjectSource: return first found config

### DIFF
--- a/vint/linting/config/config_project_source.py
+++ b/vint/linting/config/config_project_source.py
@@ -21,7 +21,6 @@ class ConfigProjectSource(ConfigFileSource):
                 proj_conf_path_tmp = project_path / basename
 
                 if proj_conf_path_tmp.is_file():
-                    proj_conf_path = proj_conf_path_tmp
-                    break
+                    return proj_conf_path_tmp
 
         return proj_conf_path


### PR DESCRIPTION
Fixes https://github.com/Kuniwak/vint/issues/194.

Maybe the `break` was meant to really break already, and the outer loop was an oversight?!