### PR TITLE
Fix typo in policy rule name

### DIFF
--- a/test/integration/vint/linting/policy/test_prohibit_implicit_scope_builtin_variable.py
+++ b/test/integration/vint/linting/policy/test_prohibit_implicit_scope_builtin_variable.py
@@ -3,7 +3,7 @@ from test.asserting.policy import PolicyAssertion, get_fixture_path
 
 from vint.linting.level import Level
 from vint.linting.policy.prohibit_implicit_scope_builtin_variable import (
-    ProhibitImplicitScopeBuitlinVariable,
+    ProhibitImplicitScopeBuiltinVariable,
 )
 
 PATH_VALID_VIM_SCRIPT = get_fixture_path(
@@ -12,15 +12,15 @@ PATH_INVALID_VIM_SCRIPT = get_fixture_path(
     'prohibit_implicit_scope_builtin_variable_invalid.vim')
 
 
-class TestProhibitImplicitScopeBuitlinVariable(PolicyAssertion, unittest.TestCase):
+class TestProhibitImplicitScopeBuiltinVariable(PolicyAssertion, unittest.TestCase):
     def test_get_violation_if_found_when_file_is_valid(self):
         self.assertFoundNoViolations(PATH_VALID_VIM_SCRIPT,
-                                     ProhibitImplicitScopeBuitlinVariable)
+                                     ProhibitImplicitScopeBuiltinVariable)
 
 
     def create_violation(self, line, column):
         return {
-            'name': 'ProhibitImplicitScopeBuitlinVariable',
+            'name': 'ProhibitImplicitScopeBuiltinVariable',
             'level': Level.WARNING,
             'position': {
                 'line': line,
@@ -37,7 +37,7 @@ class TestProhibitImplicitScopeBuitlinVariable(PolicyAssertion, unittest.TestCas
         ]
 
         self.assertFoundViolationsEqual(PATH_INVALID_VIM_SCRIPT,
-                                        ProhibitImplicitScopeBuitlinVariable,
+                                        ProhibitImplicitScopeBuiltinVariable,
                                         expected_violations)
 
 if __name__ == '__main__':

--- a/vint/linting/policy/prohibit_implicit_scope_builtin_variable.py
+++ b/vint/linting/policy/prohibit_implicit_scope_builtin_variable.py
@@ -9,9 +9,9 @@ from vint.ast.plugin.scope_plugin import (
 
 
 @register_policy
-class ProhibitImplicitScopeBuitlinVariable(AbstractPolicy):
+class ProhibitImplicitScopeBuiltinVariable(AbstractPolicy):
     def __init__(self):
-        super(ProhibitImplicitScopeBuitlinVariable, self).__init__()
+        super(ProhibitImplicitScopeBuiltinVariable, self).__init__()
         self.reference = ':help local-variable'
         self.level = Level.WARNING
 
@@ -21,8 +21,8 @@ class ProhibitImplicitScopeBuitlinVariable(AbstractPolicy):
 
 
     def is_valid(self, identifier, lint_context):
-        """ Implicit scope buitlin variables are prohibited.
-        Because it will make unexpected variable name conflict between buitlin
+        """ Implicit scope builtin variables are prohibited.
+        Because it will make unexpected variable name conflict between builtin
         and imlicit global/function local. For example:
 
             " This variable is not global variable but builtin variable.


### PR DESCRIPTION
The name of the policy rule "ProhibitImplicitScopeBuiltinVariable" is
actually implemented as "ProhibitImplicitScopeBuitlinVariable" ("t" and
"l" in Builtin are swapped).