### PR TITLE
Bump chardet requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 PyYAML ~= 3.11
 ansicolor ~= 0.2.4
-chardet ~= 3.0.3
+chardet >= 2.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 PyYAML ~= 3.11
 ansicolor ~= 0.2.4
-chardet ~= 2.3.0
+chardet ~= 3.0.3


### PR DESCRIPTION
Arch Linux has chardet 3.0.3 by now, and that causes Vint to break.