### PR TITLE
requirements.txt: Allow chardet ~= 3.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 PyYAML ~= 3.11
 ansicolor ~= 0.2.4
-chardet ~= 2.3.0
+chardet ~= 3.0.2


### PR DESCRIPTION
This allows compatibility with requests 2.16.2's requirement of chardet 3.0.2-3.

Fixes https://github.com/Kuniwak/vint/issues/146 and https://github.com/Kuniwak/vint/issues/216