### PR TITLE
Install typing when Python is older than 3.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 PyYAML ~= 3.11
 ansicolor ~= 0.2.4
 chardet >= 2.3.0
-typing >= 3.6.2

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,11 @@ def install_requires():
         requires.append('enum34 >= 1.0.4')
         # To enable pathlib in Python < 3.4
         requires.append('pathlib == 1.0.1')
+
+    if sys.version_info < (3, 6):
+        # To enable typing in Python < 3.6
+        requires.append('typing >= 3.6.2')
+
     return requires
 
 


### PR DESCRIPTION
Related #238 