### PR TITLE
Suppress warnings caused by map([], ' "x" ')

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
-pytest == 2.6.4
-pytest-cov == 1.8.1
+pytest == 3.3.2
+pytest-cov == 2.5.1
 coverage == 3.7.1

--- a/test/asserting/policy.py
+++ b/test/asserting/policy.py
@@ -65,7 +65,7 @@ class PolicyAssertion(unittest.TestCase):
         violations = linter.lint_file(path)
 
         pprint(violations)
-        assert len(violations) == len(expected_violations)
+        self.assertEqual(len(violations), len(expected_violations))
 
         for violation, expected_violation in zip_longest(violations, expected_violations):
             self.assertViolation(violation, expected_violation)

--- a/test/fixture/ast/scope_plugin/fixture_to_scope_plugin_nested_map_and_filter.vim
+++ b/test/fixture/ast/scope_plugin/fixture_to_scope_plugin_nested_map_and_filter.vim
@@ -1,0 +1,2 @@
+call map([], 'map([], "v:val")')
+call filter([], 'filter([], "v:val")')

--- a/test/fixture/policy/prohibit_unnecessary_double_quote_invalid.vim
+++ b/test/fixture/policy/prohibit_unnecessary_double_quote_invalid.vim
@@ -1,3 +1,4 @@
 " Double quote literal should be prohibited
 echo ""
 echo "foo"
+echo map([], "''")

--- a/test/fixture/policy/prohibit_unnecessary_double_quote_valid.vim
+++ b/test/fixture/policy/prohibit_unnecessary_double_quote_valid.vim
@@ -20,3 +20,4 @@ echo "'"
 
 " String literal should not be prohibited
 echo map([], '""')
+echo map([], 'map(v:val, "x")')

--- a/test/fixture/policy/prohibit_unnecessary_double_quote_valid.vim
+++ b/test/fixture/policy/prohibit_unnecessary_double_quote_valid.vim
@@ -17,3 +17,6 @@ echo "\<xxx>"
 
 " Double quote literal should not be prohibited too
 echo "'"
+
+" String literal should not be prohibited
+echo map([], '""')

--- a/test/unit/vint/ast/plugin/scope_plugin/test_map_and_filter_parser.py
+++ b/test/unit/vint/ast/plugin/scope_plugin/test_map_and_filter_parser.py
@@ -18,6 +18,7 @@ FIXTURE_BASE_PATH = Path('test', 'fixture', 'ast', 'scope_plugin')
 class Fixtures(enum.Enum):
     MAP_AND_FILTER_VARIABLE = Path(FIXTURE_BASE_PATH, 'fixture_to_scope_plugin_map_and_filter.vim')
     ISSUE_256 = Path(FIXTURE_BASE_PATH, 'fixture_to_scope_plugin_issue_256.vim')
+    NESTED = Path(FIXTURE_BASE_PATH, 'fixture_to_scope_plugin_nested_map_and_filter.vim')
 
 
 class TestMapAndFilterParser(unittest.TestCase):
@@ -72,6 +73,24 @@ class TestMapAndFilterParser(unittest.TestCase):
         got_ast = parser.process(ast)
 
         self.assertIsNotNone(got_ast)
+
+
+    def test_nested_map(self):
+        ast = self.create_ast(Fixtures.NESTED)
+        parser = MapAndFilterParser()
+        got_ast = parser.process(ast)
+
+        nested_map_ast = get_string_expr_content(got_ast['body'][0]['left'])[0]
+        self.assertIsNotNone(get_string_expr_content(nested_map_ast))
+
+
+    def test_nested_filter(self):
+        ast = self.create_ast(Fixtures.NESTED)
+        parser = MapAndFilterParser()
+        got_ast = parser.process(ast)
+
+        nested_filter_ast = get_string_expr_content(got_ast['body'][1]['left'])[0]
+        self.assertIsNotNone(get_string_expr_content(nested_filter_ast))
 
 
 if __name__ == '__main__':

--- a/vint/ast/parsing.py
+++ b/vint/ast/parsing.py
@@ -83,7 +83,7 @@ class Parser(object):
 
 
     def parse_string_expr(self, string_expr_node):
-        """ Parse a command :redir content. """
+        """ Parse a string node content. """
         string_expr_node_value = string_expr_node['value']
         string_expr_str = string_expr_node_value[1:-1]
 

--- a/vint/ast/plugin/scope_plugin/map_and_filter_parser.py
+++ b/vint/ast/plugin/scope_plugin/map_and_filter_parser.py
@@ -3,13 +3,12 @@ from vint.ast.traversing import traverse, register_traverser_extension
 from vint.ast.parsing import Parser
 
 STRING_EXPR_CONTENT = 'VINT:string_expression'
+STRING_EXPR_CONTEXT = 'VINT:string_expression_context'
 
 
 
 class MapAndFilterParser(object):
-    """ A class to make string expression in map and filter function parseable.
-    """
-
+    """ A class to make string expression in map and filter function parseable. """
     def process(self, ast):
         def enter_handler(node):
             node_type = NodeType(node['type'])
@@ -42,8 +41,7 @@ class MapAndFilterParser(object):
             if NodeType(string_expr_node['type']) is not NodeType.STRING:
                 return
 
-            parser = Parser()
-            string_expr_content_nodes = parser.parse_string_expr(string_expr_node)
+            string_expr_content_nodes = MapAndFilterParser._parse_string_expr_content_nodes(string_expr_node)
             node[STRING_EXPR_CONTENT] = string_expr_content_nodes
 
         traverse(ast, on_enter=enter_handler)
@@ -51,8 +49,30 @@ class MapAndFilterParser(object):
         return ast
 
 
+    @classmethod
+    def _parse_string_expr_content_nodes(cls, string_expr_node):
+        parser = Parser()
+        string_expr_content_nodes = parser.parse_string_expr(string_expr_node)
+
+        def enter_handler(node):
+            node[STRING_EXPR_CONTEXT] = {
+                'is_on_str_expr_context': True,
+            }
+
+        for string_expr_content_node in string_expr_content_nodes:
+            traverse(string_expr_content_node, on_enter=enter_handler)
+
+        return string_expr_content_nodes
+
+
 def get_string_expr_content(node):
     return node.get(STRING_EXPR_CONTENT)
+
+
+def get_string_context(node):
+    return node.get(STRING_EXPR_CONTEXT, {
+        'is_on_str_expr_context': False,
+    })
 
 
 @register_traverser_extension

--- a/vint/ast/plugin/scope_plugin/map_and_filter_parser.py
+++ b/vint/ast/plugin/scope_plugin/map_and_filter_parser.py
@@ -55,9 +55,12 @@ class MapAndFilterParser(object):
         string_expr_content_nodes = parser.parse_string_expr(string_expr_node)
 
         def enter_handler(node):
-            node[STRING_EXPR_CONTEXT] = {
-                'is_on_str_expr_context': True,
-            }
+            # NOTE: We need this flag only string nodes, because this flag is only for
+            # ProhibitUnnecessaryDoubleQuote.
+            if NodeType(node['type']) is NodeType.STRING:
+                node[STRING_EXPR_CONTEXT] = {
+                    'is_on_str_expr_context': True,
+                }
 
         for string_expr_content_node in string_expr_content_nodes:
             traverse(string_expr_content_node, on_enter=enter_handler)

--- a/vint/linting/policy/prohibit_unnecessary_double_quote.py
+++ b/vint/linting/policy/prohibit_unnecessary_double_quote.py
@@ -1,9 +1,11 @@
 import re
 from vint.ast.node_type import NodeType
+from vint.ast.plugin.scope_plugin.map_and_filter_parser import get_string_context
 from vint.linting.level import Level
 from vint.linting.policy.abstract_policy import AbstractPolicy
 from vint.linting.policy.reference.googlevimscriptstyleguide import get_reference_source
 from vint.linting.policy_registry import register_policy
+
 
 
 # see `:help expr-string`
@@ -54,4 +56,9 @@ class ProhibitUnnecessaryDoubleQuote(AbstractPolicy):
             return True
 
         has_escaped_char = _special_char_matcher.search(value) is not None
-        return has_escaped_char
+
+        if has_escaped_char:
+            return True
+
+        string_expr_context = get_string_context(node)
+        return string_expr_context['is_on_str_expr_context']


### PR DESCRIPTION
Before this patch, `ProhibitUnnecessaryDoubleQuote` report warnings caused by the code:

```viml
map([0, 1, 2], ' "x" ')
"                ^^^
"                Prefer single quoted strings (see Google VimScript Style Guide (Strings))
```

After this patch, Vint will suppress the warnings:

```viml
map([0, 1, 2], ' "x" ')
" (no warnings)
```

# Discussion

This feature can be an option of `ProhibitUnnecessaryDoubleQuote`.
But I feel this option is useless. Because the following code is noisy:

```
map([0, 1, 2], ' ''x'' ')
```
  