### PR TITLE
Fix UnicodeDecodeError

### DIFF
--- a/vint/encodings/decoder.py
+++ b/vint/encodings/decoder.py
@@ -1,11 +1,11 @@
 import sys
+import re
 from typing import Dict, Any
 from pprint import pformat
 from pathlib import Path
 from vint.encodings.decoding_strategy import DecodingStrategy
 
 
-SCRIPTENCODING_PREFIX = bytearray('scriptencoding', encoding='ascii')
 
 
 
@@ -43,22 +43,24 @@ def _split_by_scriptencoding(bytes_seq):
     start_index = 0
     bytes_seq_and_loc_list = []
 
-    while True:
-        end_index = bytes_seq.find(SCRIPTENCODING_PREFIX, start_index + 1)
+    for m in re.finditer(b'^\s*(scriptencoding)', bytes_seq, re.MULTILINE):
+        end_index = m.start(1)
 
-        if end_index < 0:
-            end_index = max_end_index
+        if end_index == 0:
+            continue
 
         bytes_seq_and_loc_list.append((
             "{start_index}:{end_index}".format(start_index=start_index, end_index=end_index),
             bytes_seq[start_index:end_index]
         ))
+        start_index = end_index
 
-        if end_index < max_end_index:
-            start_index = end_index
-            continue
+    bytes_seq_and_loc_list.append((
+        "{start_index}:{end_index}".format(start_index=start_index, end_index=max_end_index),
+        bytes_seq[start_index:max_end_index]
+    ))
 
-        return bytes_seq_and_loc_list
+    return bytes_seq_and_loc_list
 
 
 class EncodingDetectionError(Exception):


### PR DESCRIPTION
Original code does not take into account scriptencoding is comment or not.
So UnicodeDecodeError occures in the code

```viml
" scriptencoding とは
```
```
UnicodeDecodeError: 'ascii' codec can't decode byte ...
```

This PR fixes the problem.

Sample output:

```python
#!/usr/bin/env python
import re

def _split_by_scriptencoding(bytes_seq):
    # type: (bytes) -> [(str, bytes)]
    max_end_index = len(bytes_seq)
    start_index = 0
    bytes_seq_and_loc_list = []

    for m in re.finditer(b'^\s*(scriptencoding)', bytes_seq, re.MULTILINE):
        end_index = m.start(1)

        if end_index == 0:
            continue

        bytes_seq_and_loc_list.append((
            "{start_index}:{end_index}".format(start_index=start_index, end_index=end_index),
            bytes_seq[start_index:end_index]
        ))
        start_index = end_index

    bytes_seq_and_loc_list.append((
        "{start_index}:{end_index}".format(start_index=start_index, end_index=max_end_index),
        bytes_seq[start_index:max_end_index]
    ))

    return bytes_seq_and_loc_list


str = '''scriptencoding utf-8
" scriptencoding あ
echo 'scriptencoding い'
 scriptencoding utf-8
'''

print(_split_by_scriptencoding(str.encode()))
```

output

```
[('0:69', b'scriptencoding utf-8\n" scriptencoding \xe3\x81\x82\necho \'scriptencoding \xe3\x81\x84\'\n '), ('69:90', b'scriptencoding utf-8\n')]
```