### PR TITLE
ProhibitUnnecessaryDoubleQuote should be a style problem, not a warning?

### DIFF
--- a/test/integration/vint/linting/policy/test_prohibit_unnecessary_double_quote.py
+++ b/test/integration/vint/linting/policy/test_prohibit_unnecessary_double_quote.py
@@ -18,7 +18,7 @@ class TestProhibitUnnecessaryDoubleQuote(PolicyAssertion, unittest.TestCase):
         expected_violations = [
             {
                 'name': 'ProhibitUnnecessaryDoubleQuote',
-                'level': Level.WARNING,
+                'level': Level.STYLE_PROBLEM,
                 'position': {
                     'line': 2,
                     'column': 6,
@@ -27,7 +27,7 @@ class TestProhibitUnnecessaryDoubleQuote(PolicyAssertion, unittest.TestCase):
             },
             {
                 'name': 'ProhibitUnnecessaryDoubleQuote',
-                'level': Level.WARNING,
+                'level': Level.STYLE_PROBLEM,
                 'position': {
                     'line': 3,
                     'column': 6,

--- a/vint/linting/policy/prohibit_unnecessary_double_quote.py
+++ b/vint/linting/policy/prohibit_unnecessary_double_quote.py
@@ -31,7 +31,7 @@ class ProhibitUnnecessaryDoubleQuote(AbstractPolicy):
         super(ProhibitUnnecessaryDoubleQuote, self).__init__()
         self.description = 'Prefer single quoted strings'
         self.reference = get_reference_source('STRINGS')
-        self.level = Level.WARNING
+        self.level = Level.STYLE_PROBLEM
 
 
     def listen_node_types(self):


### PR DESCRIPTION
Maybe I'm just confused about the various levels, but single versus double quotes seems as stylistic as it gets.