### PR TITLE
Fix a broken code block for example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,7 +127,7 @@ Comment config
 
 You can enable/disable linting policies by a comment as following:
 
-..
+.. code:: vim
 
     " vint: -ProhibitAbbreviationOption
 


### PR DESCRIPTION
> " vint: -ProhibitAbbreviationOption
>
> let s:save_cpo = &cpo set cpo&vim
>
> " vint: +ProhibitAbbreviationOption
>
> " do something...
>
> " vint: -ProhibitAbbreviationOption
>
> let &cpo = s:save_cpo unlet s:save_cpo

コメントでポリシーを enable/disable するサンプルがこんな感じ↑に崩壊してしまっていたので直しました