### PR TITLE
Support --stdin-display-name and the mixed style of files and stdin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -152,7 +152,7 @@ And you can see all available options by using `--help`:
       --enable-neovim       enable Neovim syntax
       -f FORMAT, --format FORMAT
                             set output format
-      --stdin-alt-path STDIN_ALT_PATH
+      --stdin-display-name STDIN_DISPLAY_NAME
                             specify a file path that is used for reporting when
                             linting standard inputs
 

--- a/README.rst
+++ b/README.rst
@@ -122,7 +122,7 @@ You can configure linting severity, max errors, ... as following:
 
     $ vint --color --style ~/.vimrc
 
-And you can see all available options by `--help` as following:
+And you can see all available options by using `--help`:
 
 ::
     $ vint --help

--- a/README.rst
+++ b/README.rst
@@ -122,6 +122,40 @@ You can configure linting severity, max errors, ... as following:
 
     $ vint --color --style ~/.vimrc
 
+And you can see all available options by `--help` as following:
+
+::
+    $ vint --help
+    usage: vint [-h] [-v] [-V] [-e] [-w] [-s] [-m MAX_VIOLATIONS] [-c]
+                [--no-color] [-j] [-t] [--enable-neovim] [-f FORMAT]
+                [--stdin-alt-path STDIN_ALT_PATH]
+                [files [files ...]]
+    
+    Lint Vim script
+    
+    positional arguments:
+      files                 file or directory path to lint
+    
+    optional arguments:
+      -h, --help            show this help message and exit
+      -v, --version         show program's version number and exit
+      -V, --verbose         output verbose message
+      -e, --error           report only errors
+      -w, --warning         report errors and warnings
+      -s, --style-problem   report errors, warnings and style problems
+      -m MAX_VIOLATIONS, --max-violations MAX_VIOLATIONS
+                            limit max violations count
+      -c, --color           colorize output when possible
+      --no-color            do not colorize output
+      -j, --json            output json style
+      -t, --stat            output statistic info
+      --enable-neovim       enable Neovim syntax
+      -f FORMAT, --format FORMAT
+                            set output format
+      --stdin-alt-path STDIN_ALT_PATH
+                            specify a file path that is used for reporting when
+                            linting standard inputs
+
 Comment config
 ~~~~~~~~~~~~~~
 

--- a/dev_tool/show_encoding.py
+++ b/dev_tool/show_encoding.py
@@ -19,5 +19,5 @@ if __name__ == '__main__':
 
     file_path = Path(namespace['file'][0])
     decoder = Decoder(default_decoding_strategy)
-    decoder.read(file_path)
+    decoder.decode(file_path)
     pprint(decoder.debug_hint)

--- a/test/acceptance/test_cli.py
+++ b/test/acceptance/test_cli.py
@@ -144,5 +144,17 @@ class TestCLI(unittest.TestCase):
         self.assertRegex(got_output, expected_output_pattern)
 
 
+    def test_exec_vint_with_pipe(self):
+        cmd = 'echo "foo" =~ "bar" | bin/vint --stdin-display-name STDIN_TEST -'
+
+        with self.assertRaises(subprocess.CalledProcessError) as context_manager:
+            subprocess.check_output(cmd, shell=True, universal_newlines=True)
+
+        got_output = context_manager.exception.output
+
+        expected_output_pattern = '^STDIN_TEST:'
+        self.assertRegex(got_output, expected_output_pattern)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/asserting/policy.py
+++ b/test/asserting/policy.py
@@ -4,6 +4,8 @@ from pprint import pprint
 from vint.compat.itertools import zip_longest
 from vint.linting.policy_set import PolicySet
 from vint.linting.linter import Linter
+from vint.linting.config.config_default_source import ConfigDefaultSource
+from vint.linting.lint_target import LintTargetFile
 from vint.linting.level import Level
 
 
@@ -31,7 +33,7 @@ class PolicyAssertion(unittest.TestCase):
             config_dict['policies'][policy_name] = policy_options
 
         linter = Linter(policy_set, config_dict)
-        violations = linter.lint_file(path)
+        violations = linter.lint(LintTargetFile(path))
 
         pprint(violations)
         self.assertEqual(len(violations), len(expected_violations))
@@ -43,9 +45,13 @@ class PolicyAssertion(unittest.TestCase):
     def assertViolation(self, actual_violation, expected_violation):
         self.assertIsNot(actual_violation, None)
         self.assertIsNot(expected_violation, None)
+
+        pprint(actual_violation)
+
         self.assertEqual(actual_violation['name'], expected_violation['name'])
         self.assertEqual(actual_violation['position'], expected_violation['position'])
         self.assertEqual(actual_violation['level'], expected_violation['level'])
+
         self.assertIsInstance(actual_violation['description'], str)
 
 

--- a/test/integration/vint/ast/plugin/test_scope_plugin.py
+++ b/test/integration/vint/ast/plugin/test_scope_plugin.py
@@ -10,6 +10,7 @@ from vint.ast.plugin.scope_plugin.reference_reachability_tester import (
     is_declarative_identifier,
 )
 from vint.ast.plugin.scope_plugin import ScopePlugin
+from vint.linting.lint_target import LintTargetFile
 
 
 FIXTURE_BASE_PATH = Path('test', 'fixture', 'ast', 'scope_plugin')
@@ -41,7 +42,7 @@ class Fixtures(enum.Enum):
 class TestScopePlugin(unittest.TestCase):
     def create_ast(self, file_path):
         parser = Parser()
-        ast = parser.parse_file(file_path.value)
+        ast = parser.parse(LintTargetFile(file_path.value))
         return ast
 
 

--- a/test/integration/vint/linting/test_linter.py
+++ b/test/integration/vint/linting/test_linter.py
@@ -4,6 +4,7 @@ from vint.ast.node_type import NodeType
 from vint.linting.level import Level
 from vint.linting.policy.abstract_policy import AbstractPolicy
 from vint.linting.linter import Linter
+from vint.linting.lint_target import LintTargetFile
 
 INVALID_VIM_SCRIPT = Path('test', 'fixture', 'linter', 'invalid.vim')
 BROKEN_VIM_SCRIPT = Path('test', 'fixture', 'linter', 'broken.vim')
@@ -86,7 +87,7 @@ class TestLinterIntegral(unittest.TestCase):
         }
 
         linter = Linter(policy_set, config_dict_global)
-        got_violations = linter.lint_file(INVALID_VIM_SCRIPT)
+        got_violations = linter.lint(LintTargetFile(INVALID_VIM_SCRIPT))
 
         expected_violations = [
             {
@@ -147,7 +148,7 @@ class TestLinterIntegral(unittest.TestCase):
         }
 
         linter = Linter(policy_set, config_dict_global)
-        got_violations = linter.lint_file(BROKEN_VIM_SCRIPT)
+        got_violations = linter.lint(LintTargetFile(BROKEN_VIM_SCRIPT))
 
         expected_violations = [
             {

--- a/test/unit/vint/ast/plugin/scope_plugin/test_call_node_parser.py
+++ b/test/unit/vint/ast/plugin/scope_plugin/test_call_node_parser.py
@@ -10,6 +10,7 @@ from vint.ast.plugin.scope_plugin.call_node_parser import (
     get_lambda_string_expr_content,
     FUNCTION_REFERENCE_STRING_EXPR_CONTENT,
 )
+from vint.linting.lint_target import LintTargetFile
 
 
 FIXTURE_BASE_PATH = Path('test', 'fixture', 'ast', 'scope_plugin')
@@ -27,7 +28,7 @@ class Fixtures(enum.Enum):
 class TestCallNodeParser(unittest.TestCase):
     def create_ast(self, file_path):
         parser = Parser()
-        ast = parser.parse_file(file_path.value)
+        ast = parser.parse(LintTargetFile(file_path.value))
         return ast
 
 

--- a/test/unit/vint/ast/plugin/scope_plugin/test_identifier_classifier.py
+++ b/test/unit/vint/ast/plugin/scope_plugin/test_identifier_classifier.py
@@ -21,6 +21,7 @@ from vint.ast.plugin.scope_plugin.identifier_attribute import (
     IDENTIFIER_ATTRIBUTE_LAMBDA_ARGUMENT_FLAG,
     IDENTIFIER_ATTRIBUTE_LAMBDA_BODY_CONTEXT,
 )
+from vint.linting.lint_target import LintTargetFile
 
 
 FIXTURE_BASE_PATH = Path('test', 'fixture', 'ast', 'scope_plugin')
@@ -64,7 +65,7 @@ Fixtures = {
 class TestIdentifierClassifier(unittest.TestCase):
     def create_ast(self, file_path):
         parser = Parser()
-        ast = parser.parse_file(file_path)
+        ast = parser.parse(LintTargetFile(file_path))
         return ast
 
 

--- a/test/unit/vint/ast/plugin/scope_plugin/test_identifier_collector.py
+++ b/test/unit/vint/ast/plugin/scope_plugin/test_identifier_collector.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from vint.ast.parsing import Parser
 from vint.ast.plugin.scope_plugin.identifier_classifier import IdentifierClassifier
+from vint.linting.lint_target import LintTargetFile
 
 FIXTURE_BASE_PATH = Path('test', 'fixture', 'ast', 'scope_plugin')
 
@@ -15,7 +16,7 @@ Fixtures = {
 class TestIdentifierCollector(unittest.TestCase):
     def create_ast(self, file_path):
         parser = Parser()
-        ast = parser.parse_file(file_path)
+        ast = parser.parse(LintTargetFile(file_path))
 
         id_classifier = IdentifierClassifier()
         attached_ast = id_classifier.attach_identifier_attributes(ast)

--- a/test/unit/vint/ast/plugin/scope_plugin/test_redir_assignment_parser.py
+++ b/test/unit/vint/ast/plugin/scope_plugin/test_redir_assignment_parser.py
@@ -9,6 +9,7 @@ from vint.ast.plugin.scope_plugin.redir_assignment_parser import (
     RedirAssignmentParser,
     get_redir_content,
 )
+from vint.linting.lint_target import LintTargetFile
 
 
 FIXTURE_BASE_PATH = Path('test', 'fixture', 'ast', 'scope_plugin')
@@ -22,7 +23,7 @@ class Fixtures(enum.Enum):
 class TestRedirAssignmentParser(unittest.TestCase):
     def create_ast(self, file_path):
         parser = Parser()
-        ast = parser.parse_file(file_path.value)
+        ast = parser.parse(LintTargetFile(file_path.value))
         return ast
 
 

--- a/test/unit/vint/ast/plugin/scope_plugin/test_reference_reachability_tester.py
+++ b/test/unit/vint/ast/plugin/scope_plugin/test_reference_reachability_tester.py
@@ -8,6 +8,7 @@ from vint.ast.plugin.scope_plugin.reference_reachability_tester import (
     is_reachable_reference_identifier,
     is_referenced_declarative_identifier,
 )
+from vint.linting.lint_target import LintTargetFile
 
 
 FIXTURE_BASE_PATH = Path('test', 'fixture', 'ast', 'scope_plugin')
@@ -31,7 +32,7 @@ class Fixtures(enum.Enum):
 class TestReferenceReachabilityTester(unittest.TestCase):
     def create_ast(self, file_path):
         parser = Parser()
-        ast = parser.parse_file(file_path.value)
+        ast = parser.parse(LintTargetFile(file_path.value))
         return ast
 
 

--- a/test/unit/vint/ast/plugin/scope_plugin/test_scope_linker.py
+++ b/test/unit/vint/ast/plugin/scope_plugin/test_scope_linker.py
@@ -4,6 +4,8 @@ import enum
 from pathlib import Path
 
 from vint.ast.parsing import Parser
+from vint.ast.plugin.scope_plugin.scope_linker import ScopeLinker, ScopeVisibility
+from vint.linting.lint_target import LintTargetFile
 from vint.ast.plugin.scope_plugin.scope_linker import ScopeLinker
 from vint.ast.plugin.scope_plugin.scope import (
     Scope,
@@ -34,7 +36,8 @@ class Fixtures(enum.Enum):
 class TestScopeLinker(unittest.TestCase):
     def create_ast(self, file_path):
         parser = Parser()
-        ast = parser.parse_file(file_path.value)
+        lint_target = LintTargetFile(file_path.value)
+        ast = parser.parse(lint_target)
         return ast
 
 

--- a/test/unit/vint/ast/test_parsing.py
+++ b/test/unit/vint/ast/test_parsing.py
@@ -1,6 +1,7 @@
 import unittest
 from vint.ast.parsing import Parser
 from vint.ast.node_type import NodeType
+from vint.linting.lint_target import LintTargetFile
 from test.asserting.ast import get_fixture_path
 
 FIXTURE_FILE = get_fixture_path('fixture_to_parse.vim')
@@ -10,27 +11,27 @@ FIXTURE_FILE_NEOVIM = get_fixture_path('fixture_to_parse_neovim.vim')
 
 
 class TestParser(unittest.TestCase):
-    def test_parse_file(self):
+    def test_parse(self):
         parser = Parser()
-        ast = parser.parse_file(FIXTURE_FILE)
+        ast = parser.parse(LintTargetFile(FIXTURE_FILE))
         self.assertIs(ast['type'], 1)
 
 
     def test_parse_file_on_ff_dos_and_fenc_cp932(self):
         parser = Parser()
-        ast = parser.parse_file(FIXTURE_FILE_FF_DOS_FENC_CP932)
+        ast = parser.parse(LintTargetFile(FIXTURE_FILE_FF_DOS_FENC_CP932))
         self.assertIs(ast['type'], 1)
 
 
     def test_parse_file_when_neovim_enabled(self):
         parser = Parser(enable_neovim=True)
-        ast = parser.parse_file(FIXTURE_FILE_NEOVIM)
+        ast = parser.parse(LintTargetFile(FIXTURE_FILE_NEOVIM))
         self.assertIs(ast['type'], 1)
 
 
     def test_parse_empty_file(self):
         parser = Parser()
-        ast = parser.parse_file(FIXTURE_FILE_EMPTY)
+        ast = parser.parse(LintTargetFile(FIXTURE_FILE_EMPTY))
         self.assertIs(ast['type'], 1)
 
 

--- a/test/unit/vint/ast/test_traversing.py
+++ b/test/unit/vint/ast/test_traversing.py
@@ -4,6 +4,7 @@ from test.asserting.ast import get_fixture_path
 from vint.ast.parsing import Parser
 from vint.ast.node_type import NodeType
 from vint.ast.traversing import traverse, SKIP_CHILDREN
+from vint.linting.lint_target import LintTargetFile
 
 FIXTURE_FILE = get_fixture_path('fixture_to_traverse.vim')
 
@@ -11,7 +12,7 @@ FIXTURE_FILE = get_fixture_path('fixture_to_traverse.vim')
 class TestTraverse(unittest.TestCase):
     def setUp(self):
         parser = Parser()
-        self.ast = parser.parse_file(FIXTURE_FILE)
+        self.ast = parser.parse(LintTargetFile(FIXTURE_FILE))
 
     def test_traverse(self):
         expected_order_of_events = [

--- a/test/unit/vint/linting/config/test_config_next_line_comment_source.py
+++ b/test/unit/vint/linting/config/test_config_next_line_comment_source.py
@@ -1,6 +1,7 @@
 import unittest
 import enum
 from vint.linting.linter import Linter
+from vint.linting.lint_target import LintTargetFile
 from vint.linting.policy_set import PolicySet
 from vint.ast.node_type import NodeType
 from vint.linting.level import Level
@@ -20,9 +21,10 @@ class TestConfigNextLineCommentSource(ConfigSourceAssertion, unittest.TestCase):
         global_config_dict = {'cmdargs': {'severity': Level.ERROR}}
         policy_set = PolicySet([TestConfigNextLineCommentSource.ProhibitStringPolicy])
         linter = Linter(policy_set, global_config_dict)
+        lint_target = LintTargetFile(Fixtures.SIMPLE.value)
 
         reported_string_node_values = [violation['description']
-                                       for violation in linter.lint_file(Fixtures.SIMPLE.value)]
+                                       for violation in linter.lint(lint_target)]
 
         self.assertEqual(reported_string_node_values, [
             "'report me because I have no line config comments'",
@@ -34,9 +36,10 @@ class TestConfigNextLineCommentSource(ConfigSourceAssertion, unittest.TestCase):
         global_config_dict = {'cmdargs': {'severity': Level.ERROR}}
         policy_set = PolicySet([TestConfigNextLineCommentSource.ProhibitStringPolicy])
         linter = Linter(policy_set, global_config_dict)
+        lint_target = LintTargetFile(Fixtures.LAMBDA_STRING_EXPR.value)
 
         reported_string_node_values = [violation['description']
-                                       for violation in linter.lint_file(Fixtures.LAMBDA_STRING_EXPR.value)]
+                                       for violation in linter.lint(lint_target)]
 
         self.assertEqual(reported_string_node_values, [
             "'report me because I have no line config comments'",

--- a/test/unit/vint/linting/formatter/test_json_formatter.py
+++ b/test/unit/vint/linting/formatter/test_json_formatter.py
@@ -9,8 +9,7 @@ from vint.linting.level import Level
 
 class TestJSONFormatter(FormatterAssertion, unittest.TestCase):
     def test_format_violations(self):
-        cmdargs = {}
-        formatter = JSONFormatter(cmdargs)
+        formatter = JSONFormatter()
 
         violations = [
             {
@@ -21,7 +20,7 @@ class TestJSONFormatter(FormatterAssertion, unittest.TestCase):
                 'position': {
                     'line': 1,
                     'column': 2,
-                    'path': Path('path', 'to', 'file1')
+                    'path': str(Path('path', 'to', 'file1'))
                 },
             },
             {
@@ -32,7 +31,7 @@ class TestJSONFormatter(FormatterAssertion, unittest.TestCase):
                 'position': {
                     'line': 11,
                     'column': 21,
-                    'path': Path('path', 'to', 'file2')
+                    'path': str(Path('path', 'to', 'file2'))
                 },
             },
         ]

--- a/test/unit/vint/linting/policy/test_abstract_policy.py
+++ b/test/unit/vint/linting/policy/test_abstract_policy.py
@@ -1,4 +1,7 @@
 import unittest
+from io import BytesIO
+from pathlib import Path
+from vint.linting.lint_target import LintTargetBufferedStream
 from vint.linting.policy.abstract_policy import AbstractPolicy
 
 
@@ -23,7 +26,12 @@ class TestAbstractPolicy(unittest.TestCase):
         }
 
         node = {'pos': pos}
-        env = {'path': 'path/to/file.vim'}
+        lint_context = {
+            'lint_target': LintTargetBufferedStream(
+                alternate_path=Path('path/to/file.vim'),
+                buffered_io=BytesIO(),
+            )
+        }
 
         expected_violation = {
             'name': 'ConcretePolicy',
@@ -33,13 +41,13 @@ class TestAbstractPolicy(unittest.TestCase):
             'position': {
                 'column': 3,
                 'line': 3,
-                'path': 'path/to/file.vim',
+                'path': Path('path/to/file.vim'),
             },
         }
 
         policy = ConcretePolicy()
         self.assertEqual(
-            policy.create_violation_report(node, env),
+            policy.create_violation_report(node, lint_context),
             expected_violation)
 
     def test_get_policy_options(self):

--- a/test/unit/vint/linting/test_cli.py
+++ b/test/unit/vint/linting/test_cli.py
@@ -1,7 +1,7 @@
 import unittest
 from vint.compat.unittest import mock
 
-from vint.linting.cli import CLI
+from vint.linting.cli import start_cli
 from vint.bootstrap import import_all_policies
 
 
@@ -9,15 +9,14 @@ class TestCLI(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # For test_start_with_invalid_file_path.
-        # The test case want to load saveral policies.
+        # The test case want to load several policies.
         import_all_policies()
 
 
     def assertExitWithSuccess(self, argv):
         with mock.patch('sys.argv', argv):
             with self.assertRaises(SystemExit) as e:
-                cli = CLI()
-                cli.start()
+                start_cli()
 
             self.assertEqual(e.exception.code, 0)
 
@@ -25,8 +24,7 @@ class TestCLI(unittest.TestCase):
     def assertExitWithFailure(self, argv):
         with mock.patch('sys.argv', argv):
             with self.assertRaises(SystemExit) as e:
-                cli = CLI()
-                cli.start()
+                start_cli()
 
             self.assertNotEqual(e.exception.code, 0)
 
@@ -60,6 +58,13 @@ class TestCLI(unittest.TestCase):
     def test_passing_code_to_stdin_lints_the_code_from_stdin(self):
         argv = ['bin/vint', '-']
         self.assertExitWithSuccess(argv)
+
+
+    @mock.patch('sys.stdin', open('test/fixture/cli/valid1.vim'))
+    def test_multiple_stdin_symbol(self):
+        argv = ['bin/vint', '-', '-']
+        self.assertExitWithFailure(argv)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit/vint/linting/test_env.py
+++ b/test/unit/vint/linting/test_env.py
@@ -27,12 +27,12 @@ class TestEnv(unittest.TestCase):
                 'warning': True,
                 'max_violations': 10,
             },
-            'file_paths': set([
+            'file_paths': [
                 Path(FIXTURE_PATH, '1.vim'),
                 Path(FIXTURE_PATH, '2.vim'),
                 Path(FIXTURE_PATH, 'sub', '3.vim'),
                 Path(FIXTURE_PATH, 'sub', '4.vim'),
-            ]),
+            ],
             'home_path': home,
             'xdg_config_home': xdg_config_home,
             'cwd': cwd,

--- a/test/unit/vint/linting/test_lint_target.py
+++ b/test/unit/vint/linting/test_lint_target.py
@@ -1,0 +1,62 @@
+import unittest
+from io import BytesIO
+from pathlib import Path
+import enum
+
+
+from vint.linting.lint_target import (
+    AbstractLintTarget,
+    LintTargetFile,
+    LintTargetBufferedStream,
+    CachedLintTarget,
+)
+
+
+class Fixture(enum.Enum):
+    FILE = Path('test', 'fixture', 'lint_target.vim')
+
+
+
+class TestLintTarget(unittest.TestCase):
+    def test_file(self):
+        lint_target = LintTargetFile(Fixture.FILE.value)
+
+        bytes_seq = lint_target.read()
+        self.assertIsNotNone(bytes_seq)
+        self.assertEqual(Fixture.FILE.value, lint_target.path)
+
+
+    def test_buffered_stream(self):
+        alternate_path = Path('dummy'),
+        lint_target = LintTargetBufferedStream(
+            alternate_path=alternate_path,
+            buffered_io=BytesIO()
+        )
+
+        bytes_seq = lint_target.read()
+        self.assertIsNotNone(bytes_seq)
+        self.assertEqual(alternate_path, lint_target.path)
+
+
+    def test_cached(self):
+        path_stub = Path('stub')
+        lint_target = CachedLintTarget(LintTargetStub(path_stub, bytes()))
+
+        bytes_seq = lint_target.read()
+        self.assertIsNotNone(bytes_seq)
+        self.assertEqual(path_stub, lint_target.path)
+
+
+
+class LintTargetStub(AbstractLintTarget):
+    def __init__(self, path, bytes_seq): # type: (Path, bytes) -> None
+        super(LintTargetStub, self).__init__(path)
+        self.bytes_seq = bytes_seq
+
+
+    def read(self): # type: () -> bytes
+        return self.bytes_seq
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vint/asset/default_config.yaml
+++ b/vint/asset/default_config.yaml
@@ -7,6 +7,7 @@ cmdargs:
   json: no
   env:
     neovim: no
+  stdin_alt_path: stdin
 
 policies:
   # Experimental

--- a/vint/asset/default_config.yaml
+++ b/vint/asset/default_config.yaml
@@ -7,7 +7,7 @@ cmdargs:
   json: no
   env:
     neovim: no
-  stdin_alt_path: stdin
+  stdin_display_name: stdin
 
 policies:
   # Experimental

--- a/vint/bootstrap.py
+++ b/vint/bootstrap.py
@@ -2,7 +2,7 @@ import importlib
 import pkgutil
 from pathlib import Path
 
-from vint.linting.cli import CLI
+from vint.linting.cli import start_cli
 import logging
 
 
@@ -18,8 +18,7 @@ def init_linter():
 
 
 def init_cli():
-    cli = CLI()
-    cli.start()
+    start_cli()
 
 
 def import_all_policies():

--- a/vint/linting/cli.py
+++ b/vint/linting/cli.py
@@ -1,6 +1,7 @@
+from typing import Dict, Any, List
 import sys
 from argparse import ArgumentParser
-from pathlib import PosixPath
+from pathlib import Path
 import pkg_resources
 import logging
 
@@ -11,161 +12,183 @@ from vint.linting.config.config_cmdargs_source import ConfigCmdargsSource
 from vint.linting.config.config_default_source import ConfigDefaultSource
 from vint.linting.config.config_global_source import ConfigGlobalSource
 from vint.linting.config.config_project_source import ConfigProjectSource
+from vint.linting.config.config_util import get_config_value
+from vint.linting.lint_target import (
+    AbstractLintTarget,
+    LintTargetFile,
+    LintTargetBufferedStream,
+    CachedLintTarget,
+)
 from vint.linting.policy_set import PolicySet
+from vint.linting.formatter.abstract_formatter import AbstractFormatter
 from vint.linting.policy_registry import get_policy_classes
 from vint.linting.formatter.formatter import Formatter
 from vint.linting.formatter.json_formatter import JSONFormatter
 from vint.linting.formatter.statistic_formatter import StatisticFormatter
 
-class CLI(object):
-    def start(self):
-        env = self._build_env(sys.argv)
-        self._validate(env)
+_stdin_symbol = Path('-')
 
-        self._adjust_log_level(env)
 
-        config_dict = self._build_config_dict(env)
-        violations = self._lint_all(env, config_dict)
+def start_cli():
+    env = _build_env(sys.argv)
+    _validate(env)
 
-        parser = self._build_argparser()
+    _adjust_log_level(env)
 
-        if len(violations) == 0:
-            parser.exit(status=0)
+    config_dict = _build_config_dict(env)
+    violations = _lint_all(env, config_dict)
 
-        self._print_violations(violations, config_dict)
+    parser = _build_arg_parser()
+
+    if len(violations) == 0:
+        parser.exit(status=0)
+
+    _print_violations(violations, config_dict)
+    parser.exit(status=1)
+
+
+def _validate(env): # type: (Dict[str, Any]) -> None
+    parser = _build_arg_parser()
+    paths_to_lint = env['file_paths']
+
+    if len(paths_to_lint) == 0:
+        logging.error('nothing to check')
+        parser.print_help()
         parser.exit(status=1)
 
+    if paths_to_lint.count(_stdin_symbol) > 1:
+        logging.error('number of "-" must be less than 2')
+        parser.exit(status=1)
 
-    def _validate(self, env):
-        parser = self._build_argparser()
-        paths_to_lint = env['file_paths']
-
-        if len(paths_to_lint) == 0:
-            logging.error('nothing to check')
-            parser.print_help()
+    for path_to_lint in filter(lambda path: path != _stdin_symbol, paths_to_lint):
+        if not path_to_lint.exists() or not path_to_lint.is_file():
+            logging.error('no such file or directory: `{path}`'.format(
+                path=str(path_to_lint)))
             parser.exit(status=1)
 
-        if not self._should_read_from_stdin(env):
-            for path_to_lint in paths_to_lint:
-                if not path_to_lint.exists() or not path_to_lint.is_file():
-                    logging.error('no such file or directory: `{path}`'.format(
-                        path=str(path_to_lint)))
-                    parser.exit(status=1)
+
+def _build_env(argv):
+    """ Build an environment object.
+    This method take an argv parameter to make function pure.
+    """
+    cmdargs = _build_cmdargs(argv)
+    env = build_environment(cmdargs)
+    return env
 
 
-    def _build_config_dict(self, env):
-        config = ConfigContainer(
-            ConfigDefaultSource(env),
-            ConfigGlobalSource(env),
-            ConfigProjectSource(env),
-            ConfigCmdargsSource(env),
+def _build_cmdargs(argv):
+    """ Build command line arguments dict to use;
+    - displaying usages
+    - vint.linting.env.build_environment
+
+    This method take an argv parameter to make function pure.
+    """
+    parser = _build_arg_parser()
+    namespace = parser.parse_args(argv[1:])
+
+    cmdargs = vars(namespace)
+    return cmdargs
+
+
+def _build_arg_parser():
+    parser = ArgumentParser(prog='vint', description='Lint Vim script')
+
+    parser.add_argument('-v', '--version', action='version', version=_get_version())
+    parser.add_argument('-V', '--verbose', action='store_const', const=True, help='output verbose message')
+    parser.add_argument('-e', '--error', action='store_const', const=True, help='report only errors')
+    parser.add_argument('-w', '--warning', action='store_const', const=True, help='report errors and warnings')
+    parser.add_argument('-s', '--style-problem', action='store_const', const=True, help='report errors, warnings and style problems')
+    parser.add_argument('-m', '--max-violations', type=int, help='limit max violations count')
+    parser.add_argument('-c', '--color', action='store_const', const=True, help='colorize output when possible')
+    parser.add_argument('--no-color', action='store_const', const=True, help='do not colorize output')
+    parser.add_argument('-j', '--json', action='store_const', const=True, help='output json style')
+    parser.add_argument('-t', '--stat', action='store_const', const=True, help='output statistic info')
+    parser.add_argument('--enable-neovim', action='store_const', const=True, help='enable Neovim syntax')
+    parser.add_argument('-f', '--format', help='set output format')
+    parser.add_argument('--stdin-alt-path', type=str, help='specify a file path that is used for reporting when linting standard inputs')
+    parser.add_argument('files', nargs='*', help='file or directory path to lint')
+
+    return parser
+
+
+def _build_config_dict(env): # type: (Dict[str, Any]) -> Dict[str, Any]
+    config = ConfigContainer(
+        ConfigDefaultSource(env),
+        ConfigGlobalSource(env),
+        ConfigProjectSource(env),
+        ConfigCmdargsSource(env),
+    )
+
+    return config.get_config_dict()
+
+
+def _lint_all(env, config_dict): # type: (Dict[str, Any], Dict[str, Any]) -> List[Dict[str, Any]]
+    paths_to_lint = env['file_paths']
+    violations = []
+    linter = _build_linter(config_dict)
+
+    for path in paths_to_lint:
+        lint_target = _build_lint_target(path, config_dict)
+        violations += linter.lint(lint_target)
+
+    return violations
+
+
+def _build_linter(config_dict): # type: (Dict[str, Any]) -> Linter
+    policy_set = PolicySet(get_policy_classes())
+    linter = Linter(policy_set, config_dict)
+    return linter
+
+
+def _print_violations(violations, config_dict): # type: (List[Dict[str, Any]], Dict[str, Any]) -> None
+    formatter = _build_formatter(config_dict)
+    output = formatter.format_violations(violations)
+
+    print(output)
+
+
+def _build_formatter(config_dict): # type: (Dict[str, Any]) -> AbstractFormatter
+    if 'cmdargs' not in config_dict:
+        return Formatter(config_dict)
+
+    cmdargs = config_dict['cmdargs']
+    if 'json' in cmdargs and cmdargs['json']:
+        return JSONFormatter()
+    elif 'stat' in cmdargs and cmdargs['stat']:
+        return StatisticFormatter(config_dict)
+    else:
+        return Formatter(config_dict)
+
+
+def _get_version():
+    # In unit tests, pkg_resources cannot find vim-vint.
+    # So, I decided to return dummy version
+    try:
+        version = pkg_resources.require('vim-vint')[0].version
+    except pkg_resources.DistributionNotFound:
+        version = 'test_mode'
+
+    return version
+
+
+def _adjust_log_level(env):
+    cmdargs = env['cmdargs']
+
+    is_verbose = cmdargs.get('verbose', False)
+    log_level = logging.DEBUG if is_verbose else logging.WARNING
+
+    logger = logging.getLogger()
+    logger.setLevel(log_level)
+
+
+def _build_lint_target(path, config_dict): # type: (Path, Dict[str, Any]) -> AbstractLintTarget
+    if path == _stdin_symbol:
+        stdin_alt_path = get_config_value(config_dict, ['cmdargs', 'stdin_alt_path'])
+        lint_target = LintTargetBufferedStream(
+            alternate_path=Path(stdin_alt_path),
+            buffered_io=sys.stdin.buffer
         )
-
-        return config.get_config_dict()
-
-
-    def _build_argparser(self):
-        parser = ArgumentParser(prog='vint', description='Lint Vim script')
-
-        parser.add_argument('-v', '--version', action='version', version=self._get_version())
-        parser.add_argument('-V', '--verbose', action='store_const', const=True, help='output verbose message')
-        parser.add_argument('-e', '--error', action='store_const', const=True, help='report only errors')
-        parser.add_argument('-w', '--warning', action='store_const', const=True, help='report errors and warnings')
-        parser.add_argument('-s', '--style-problem', action='store_const', const=True, help='report errors, warnings and style problems')
-        parser.add_argument('-m', '--max-violations', type=int, help='limit max violations count')
-        parser.add_argument('-c', '--color', action='store_const', const=True, help='colorize output when possible')
-        parser.add_argument('--no-color', action='store_const', const=True, help='do not colorize output')
-        parser.add_argument('-j', '--json', action='store_const', const=True, help='output json style')
-        parser.add_argument('-t', '--stat', action='store_const', const=True, help='output statistic info')
-        parser.add_argument('--enable-neovim', action='store_const', const=True, help='Enable Neovim syntax')
-        parser.add_argument('-f', '--format', help='set output format')
-        parser.add_argument('files', nargs='*', help='file or directory path to lint')
-
-        return parser
-
-
-    def _build_cmdargs(self, argv):
-        """ Build command line arguments dict to use;
-        - displaying usages
-        - vint.linting.env.build_environment
-
-        This method take an argv parameter to make function pure.
-        """
-        parser = self._build_argparser()
-        namespace = parser.parse_args(argv[1:])
-
-        cmdargs = vars(namespace)
-        return cmdargs
-
-
-    def _build_env(self, argv):
-        """ Build an environment object.
-        This method take an argv parameter to make function pure.
-        """
-        cmdargs = self._build_cmdargs(argv)
-        env = build_environment(cmdargs)
-        return env
-
-
-    def _build_linter(self, config_dict):
-        policy_set = PolicySet(get_policy_classes())
-        linter = Linter(policy_set, config_dict)
-        return linter
-
-
-    def _lint_all(self, env, config_dict):
-        paths_to_lint = env['file_paths']
-        violations = []
-        linter = self._build_linter(config_dict)
-
-        if self._should_read_from_stdin(env):
-            violations += linter.lint_text(sys.stdin.read())
-        else:
-            for file_path in paths_to_lint:
-                violations += linter.lint_file(file_path)
-
-        return violations
-
-    def _should_read_from_stdin(self, env):
-        return len(env['file_paths']) == 1 and PosixPath('-') in env['file_paths']
-
-
-    def _get_formatter(self, config_dict):
-        if 'cmdargs' not in config_dict:
-            return Formatter(config_dict)
-
-        cmdargs = config_dict['cmdargs']
-        if 'json' in cmdargs and cmdargs['json']:
-            return JSONFormatter(config_dict)
-        elif 'stat' in cmdargs and cmdargs['stat']:
-            return StatisticFormatter(config_dict)
-        else:
-            return Formatter(config_dict)
-
-
-    def _print_violations(self, violations, config_dict):
-        formatter = self._get_formatter(config_dict)
-        output = formatter.format_violations(violations)
-
-        print(output)
-
-
-    def _get_version(self):
-        # In unit tests, pkg_resources cannot find vim-vint.
-        # So, I decided to return dummy version
-        try:
-            version = pkg_resources.require('vim-vint')[0].version
-        except pkg_resources.DistributionNotFound:
-            version = 'test_mode'
-
-        return version
-
-
-    def _adjust_log_level(self, env):
-        cmdargs = env['cmdargs']
-
-        is_verbose = cmdargs.get('verbose', False)
-        log_level = logging.DEBUG if is_verbose else logging.WARNING
-
-        logger = logging.getLogger()
-        logger.setLevel(log_level)
+        return CachedLintTarget(lint_target)
+    else:
+        lint_target = LintTargetFile(path)
+        return CachedLintTarget(lint_target)

--- a/vint/linting/cli.py
+++ b/vint/linting/cli.py
@@ -194,12 +194,21 @@ def _build_lint_target(path, config_dict): # type: (Path, Dict[str, Any]) -> Abs
                 buffered_io=sys.stdin.buffer
             )
         else:
+            # NOTE: Python 2 on Windows opens sys.stdin in text mode, and
+            # binary data that read from it becomes corrupted on \r\n
+            # SEE: https://stackoverflow.com/questions/2850893/reading-binary-data-from-stdin/38939320#38939320
+            if sys.platform == 'win32':
+                # set sys.stdin to binary mode
+                import os, msvcrt
+                msvcrt.setmode(sys.stdin.fileno(), os.O_BINARY)
+
             lint_target = LintTargetBufferedStream(
                 alternate_path=Path(stdin_alt_path),
                 buffered_io=sys.stdin
             )
 
         return CachedLintTarget(lint_target)
+
     else:
         lint_target = LintTargetFile(path)
         return CachedLintTarget(lint_target)

--- a/vint/linting/cli.py
+++ b/vint/linting/cli.py
@@ -105,7 +105,7 @@ def _build_arg_parser():
     parser.add_argument('-t', '--stat', action='store_const', const=True, help='output statistic info')
     parser.add_argument('--enable-neovim', action='store_const', const=True, help='enable Neovim syntax')
     parser.add_argument('-f', '--format', help='set output format')
-    parser.add_argument('--stdin-alt-path', type=str, help='specify a file path that is used for reporting when linting standard inputs')
+    parser.add_argument('--stdin-display-name', type=str, help='specify a file path that is used for reporting when linting standard inputs')
     parser.add_argument('files', nargs='*', help='file or directory path to lint')
 
     return parser
@@ -183,7 +183,7 @@ def _adjust_log_level(env):
 
 def _build_lint_target(path, config_dict): # type: (Path, Dict[str, Any]) -> AbstractLintTarget
     if path == _stdin_symbol:
-        stdin_alt_path = get_config_value(config_dict, ['cmdargs', 'stdin_alt_path'])
+        stdin_alt_path = get_config_value(config_dict, ['cmdargs', 'stdin_display_name'])
 
         # NOTE: In Python 3, sys.stdin is a string not bytes. Then we can get bytes by sys.stdin.buffer.
         #       But in Python 2, sys.stdin.buffer is not defined. But we can get bytes by sys.stdin directly.

--- a/vint/linting/config/config_cmdargs_source.py
+++ b/vint/linting/config/config_cmdargs_source.py
@@ -34,6 +34,7 @@ class ConfigCmdargsSource(ConfigSource):
         config_dict = self._normalize_max_violations(env, config_dict)
         config_dict = self._normalize_format(env, config_dict)
         config_dict = self._normalize_env(env, config_dict)
+        config_dict = self._normalize_stdin_filename(env, config_dict)
 
         return config_dict
 
@@ -114,3 +115,8 @@ class ConfigCmdargsSource(ConfigSource):
             config_dict_cmdargs['env'] = {'neovim': True}
 
         return config_dict
+
+
+    def _normalize_stdin_filename(self, env, config_dict):
+        return self._pass_config_by_key('stdin_alt_path', env, config_dict)
+

--- a/vint/linting/config/config_cmdargs_source.py
+++ b/vint/linting/config/config_cmdargs_source.py
@@ -118,5 +118,5 @@ class ConfigCmdargsSource(ConfigSource):
 
 
     def _normalize_stdin_filename(self, env, config_dict):
-        return self._pass_config_by_key('stdin_alt_path', env, config_dict)
+        return self._pass_config_by_key('stdin_display_name', env, config_dict)
 

--- a/vint/linting/env.py
+++ b/vint/linting/env.py
@@ -1,3 +1,4 @@
+import sys
 import os
 import os.path
 from pathlib import Path
@@ -10,7 +11,7 @@ def build_environment(cmdargs):
         'home_path': _get_home_path(),
         'xdg_config_home': _get_xdg_config_home(),
         'cwd': _get_cwd(),
-        'file_paths': _get_file_paths(cmdargs)
+        'file_paths': _get_file_paths(cmdargs),
     }
 
 
@@ -28,7 +29,7 @@ def _get_file_paths(cmdargs):
 
     found_file_paths = find_vim_script(map(Path, cmdargs['files']))
 
-    return set(found_file_paths)
+    return found_file_paths
 
 
 def _get_xdg_config_home():

--- a/vint/linting/file_filter.py
+++ b/vint/linting/file_filter.py
@@ -9,9 +9,8 @@ def find_vim_script(file_paths):
     for file_path in file_paths:
         if file_path.is_dir():
             vim_script_file_paths += _find_vim_script_into_dir(file_path)
-            continue
-
-        vim_script_file_paths.append(file_path)
+        else:
+            vim_script_file_paths.append(file_path)
 
     return vim_script_file_paths
 
@@ -31,7 +30,7 @@ def _find_vim_script_into_dir(dir_path):
             vim_script_file_paths += _find_vim_script_into_dir(file_path)
             continue
 
-    return vim_script_file_paths
+    return sorted(vim_script_file_paths)
 
 
 def _is_vim_script(file_path):

--- a/vint/linting/formatter/abstract_formatter.py
+++ b/vint/linting/formatter/abstract_formatter.py
@@ -1,0 +1,6 @@
+from typing import List, Dict, Any
+
+
+class AbstractFormatter:
+    def format_violations(self, violations): # type: (List[Dict[str, Any]]) -> str
+        raise NotImplementedError

--- a/vint/linting/formatter/abstract_formatter.py
+++ b/vint/linting/formatter/abstract_formatter.py
@@ -1,6 +1,6 @@
 from typing import List, Dict, Any
 
 
-class AbstractFormatter:
+class AbstractFormatter(object):
     def format_violations(self, violations): # type: (List[Dict[str, Any]]) -> str
         raise NotImplementedError

--- a/vint/linting/formatter/json_formatter.py
+++ b/vint/linting/formatter/json_formatter.py
@@ -1,33 +1,38 @@
+from typing import List, Dict, Any
 import json
 from pathlib import Path
+from vint.linting.formatter.abstract_formatter import AbstractFormatter
 
 
 
-class JSONFormatter(object):
-    def __init__(self, env):
+class JSONFormatter(AbstractFormatter):
+    def __init__(self): # type: () -> None
+        super(JSONFormatter, self).__init__()
         pass
 
 
-    def format_violations(self, violations):
-        return json.dumps(self._normalize_violations(violations))
+    def format_violations(self, violations): # type: (List[Dict[str, Any]]) -> str
+        return json.dumps(_normalize_violations(violations))
 
 
-    def _normalize_violations(self, violations):
-        line_number = lambda violation: violation['position']['line']
-        sorted_violations = sorted(violations, key=line_number)
 
-        normalized_violations = map(self._normalize_violation, sorted_violations)
+def _normalize_violations(violations): # type: (List[Dict[str, Any]]) -> List[Dict[str, Any]]
+    line_number = lambda violation: violation['position']['line']
+    sorted_violations = sorted(violations, key=line_number)
 
-        return list(normalized_violations)
+    normalized_violations = map(_normalize_violation, sorted_violations)
+
+    return list(normalized_violations)
 
 
-    def _normalize_violation(self, violation):
-        return {
-            'file_path': str(Path(violation['position']['path'])),
-            'line_number': violation['position']['line'],
-            'column_number': violation['position']['column'],
-            'severity': violation['level'].name.lower(),
-            'description': violation['description'],
-            'policy_name': violation['name'],
-            'reference': violation['reference'],
-        }
+
+def _normalize_violation(violation): # type: (Dict[str, Any]) -> Dict[str, Any]
+    return {
+        'file_path': str(Path(violation['position']['path'])),
+        'line_number': violation['position']['line'],
+        'column_number': violation['position']['column'],
+        'severity': violation['level'].name.lower(),
+        'description': violation['description'],
+        'policy_name': violation['name'],
+        'reference': violation['reference'],
+    }

--- a/vint/linting/formatter/statistic_formatter.py
+++ b/vint/linting/formatter/statistic_formatter.py
@@ -1,8 +1,9 @@
+from typing import List, Dict, Any
 from vint.linting.formatter.formatter import Formatter
 
 
 class StatisticFormatter(Formatter):
-    def format_violations(self, violations):
+    def format_violations(self, violations): # type: (List[Dict[str, Any]]) -> str
         violations_count = len(violations)
 
         output = super(StatisticFormatter, self).format_violations(violations) + '\n'

--- a/vint/linting/lint_target.py
+++ b/vint/linting/lint_target.py
@@ -1,0 +1,52 @@
+from typing import Optional
+from pathlib import Path
+from io import BufferedIOBase
+
+
+
+class AbstractLintTarget:
+    def __init__(self, path): # type: (Path) -> None
+        self.path = path
+
+
+    def read(self): # type: () -> bytes
+        raise NotImplementedError()
+
+
+class LintTargetFile(AbstractLintTarget):
+    def __init__(self, path):
+        # type: (Path) -> None
+        super(LintTargetFile, self).__init__(path)
+
+
+    def read(self): # type: () -> bytes
+        with self.path.open('rb') as f:
+            return f.read()
+
+
+class LintTargetBufferedStream(AbstractLintTarget):
+    def __init__(self, alternate_path, buffered_io):
+        # type: (Path, BufferedIOBase) -> None
+        super(LintTargetBufferedStream, self).__init__(alternate_path)
+        self._buffered_io = buffered_io
+
+
+    def read(self): # type: () -> bytes
+        return self._buffered_io.read()
+
+
+class CachedLintTarget(AbstractLintTarget):
+    def __init__(self, lint_target):
+        # type: (AbstractLintTarget) -> None
+        super(CachedLintTarget, self).__init__(lint_target.path)
+        self._target = lint_target
+        self._cached_bytes = None  # type: Optional[bytes]
+
+
+    def read(self): # type: () -> bytes
+        if self._cached_bytes is not None:
+            return self._cached_bytes
+
+        result = self._target.read()
+        self._cached_bytes = result
+        return result

--- a/vint/linting/lint_target.py
+++ b/vint/linting/lint_target.py
@@ -4,7 +4,7 @@ from io import BufferedIOBase
 
 
 
-class AbstractLintTarget:
+class AbstractLintTarget(object):
     def __init__(self, path): # type: (Path) -> None
         self.path = path
 

--- a/vint/linting/policy/abstract_policy.py
+++ b/vint/linting/policy/abstract_policy.py
@@ -28,7 +28,7 @@ class AbstractPolicy(object):
             'position': {
                 'line': node['pos']['lnum'],
                 'column': node['pos']['col'],
-                'path': lint_context['path'],
+                'path': lint_context['lint_target'].path,
             },
         }
 

--- a/vint/linting/policy/prohibit_no_abort_function.py
+++ b/vint/linting/policy/prohibit_no_abort_function.py
@@ -24,7 +24,7 @@ class ProhibitNoAbortFunction(AbstractPolicy):
         This policy prohibits functions in autoload that have no 'abort' or bang
         """
 
-        if 'autoload' not in lint_context['path'].parts:
+        if 'autoload' not in lint_context['lint_target'].path.parts:
             return True
 
         has_bang = node['ea']['forceit'] != 0


### PR DESCRIPTION
Support `--stdin-display-name` and mixed style linting such as `vint a.vim - b.vim` (in commented at #240).