### PR TITLE
Fix inconsistency word 'yaml' and 'yml'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ The default configuration is defined in
 User config
 ~~~~~~~~~~~
 
-You can configure global Vint config by ``~/.vintrc.yaml`` as following:
+You can configure global Vint config by ``~/.vintrc.yml`` as following:
 
 .. code:: yaml
 
@@ -85,7 +85,7 @@ summary <https://github.com/Kuniwak/vint/wiki/Vint-linting-policy-summary>`__.
 Project config
 ~~~~~~~~~~~~~~
 
-You can configure project local Vint config by ``.vintrc.yaml`` as
+You can configure project local Vint config by ``.vintrc.yml`` as
 following:
 
 .. code:: yaml


### PR DESCRIPTION
Hi :smile: 

Now the word 'yaml' and 'yml' are mixed at README.rst.
I unified it to 'yml'!

Please accept this.
Or dicard this and unify to 'yaml' if you don't like 'yml' :D