### PR TITLE
Clarify the ProhibitNoAbortFunction message

### DIFF
--- a/vint/linting/policy/prohibit_no_abort_function.py
+++ b/vint/linting/policy/prohibit_no_abort_function.py
@@ -7,7 +7,7 @@ from vint.linting.policy_registry import register_policy
 
 @register_policy
 class ProhibitNoAbortFunction(AbstractPolicy):
-    description = 'Use the abort attribute for functions in autoload'
+    description = 'Use the abort attribute and ! for functions in autoload'
     reference = get_reference_source('FUNCTIONS')
     level = Level.WARNING
 


### PR DESCRIPTION
The ProhibitNoAbortFunction checks for both the abort attribute and
whether the bang is used for the function command, but the error didn't
mention this.

This is quite confusing, and it took me a while to figure out why vint
was failing on two functions in my project. This should clarify it.

Fixes #232