### PR TITLE
tests: revisit/fix test_cli_vital

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 source = .
 branch = true
+omit = vint/_bundles/*
 
 [report]
 show_missing = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,44 @@
-sudo: false
 language: python
 dist: xenial
 
+git:
+  submodules: false
+
 env:
   global:
-    PYTEST_ADDOPTS="--cov=vint --cov=test --cov-report=xml --cov-report=term-missing:skip-covered"
+    PYTEST_ADDOPTS="--cov-report=xml"
 
-python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "3.7"
+jobs:
+  include:
+    - name: Python 3.7 (integration)
+      python: "3.7"
+      env: TOXENV=py37-cov
+      git:
+        # Check out vital.vim for test_cli_vital.
+        submodules: true
+    - name: Python 2.7
+      python: "2.7"
+      env: TOXENV=py27-cov
+    - name: Python 3.6
+      python: "3.6"
+      env: TOXENV=py36-cov
+    - name: Python 3.5
+      python: "3.5"
+      env: TOXENV=py35-cov
+    - name: Python 3.4
+      python: "3.4"
+      env: TOXENV=py34-cov
 
 install:
-  - pip install tox tox-travis
+  - pip install tox
 
 script:
   - tox
 
 after_success:
-  - pip install codecov
-  - codecov -X search gcov pycov -f coverage.xml --required
+  - bash <(curl -s https://codecov.io/bash) -f coverage.xml -X fix
   # coveralls only support one env.
-  - if [ "$TOXENV" = py36 ]; then pip install coveralls; coveralls; fi
+  - if [ "$TOXENV" = py37-cov ]; then pip install coveralls; coveralls; fi
 
 notifications:
   email: false

--- a/test/acceptance/test_cli_vital.py
+++ b/test/acceptance/test_cli_vital.py
@@ -1,29 +1,24 @@
-import unittest
-from pathlib import Path
+import os
 import subprocess
 import sys
+from pathlib import Path
+
+import pytest
+
+vital_dir = Path("test", "fixture", "cli", "vital.vim")
 
 
-class TestVintDoNotDiedWhenLintingVital(unittest.TestCase):
-    def assertVintStillAlive(self, args):
-        cmd = [sys.executable, '-m'] + args
-        try:
-            got_output = subprocess.check_output(cmd,
-                                                 stderr=subprocess.STDOUT,
-                                                 universal_newlines=True)
-        except subprocess.CalledProcessError as err:
-            got_output = err.output
-
-        unexpected_keyword = 'Traceback'
-        self.assertFalse(unexpected_keyword in got_output,
-                         'vint was died when linting vital.vim: ' + got_output)
-
-
-    def test_survive_after_linting(self):
-        vital_dir = str(Path('test', 'fixture', 'cli', 'vital.vim'))
-
-        self.assertVintStillAlive([vital_dir])
-
-
-if __name__ == '__main__':
-    unittest.main()
+@pytest.mark.skipif(
+    not os.path.exists(str(vital_dir / "autoload")),
+    reason="vital.vim submodule not checked out",
+)
+def test_survive_after_linting():
+    """Test that it handles vital.vim, without crashing."""
+    cmd = [sys.executable, "-m", "vint", vital_dir]
+    try:
+        output = subprocess.check_output(
+            cmd, stderr=subprocess.STDOUT, universal_newlines=True
+        )
+    except subprocess.CalledProcessError as err:
+        output = err.stdout
+    assert "Traceback" not in output

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36
+envlist = py27, py37
 
 [testenv]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = py27, py37
 [testenv]
 setenv =
   PYTHONDONTWRITEBYTECODE=1
+  cov: PYTEST_ADDOPTS=--cov --cov-report=term-missing:skip-covered {env:PYTEST_ADDOPTS:}
 passenv = PYTEST_ADDOPTS
 extras = testing
 commands = pytest {posargs:test}


### PR DESCRIPTION
It was not working after fadce51 at all, but did not report the failure
correctly.

It fails currently ("Undefined variable: s:next" etc),
https://github.com/Kuniwak/vint/issues/274 - but gets skipped without
the submodule being checked out.