### PR TITLE
Add support for using as a pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+---
+- id: vint
+  name: Vint Vim script linting
+  description: Lints all vim files
+  language: python
+  entry: vint
+  types: [vim]


### PR DESCRIPTION
This allows repos using pre-commit (https://pre-commit.com) to run vint
before committing any changes and to keep repos consistent.

You can see an example of usage in my vim settings repo:

    https://github.com/ViViDboarder/vim-settings

The `.pre-commit-config.yaml` file contains the actual configuration. In
addition, I've got some handy targets in my `Makefile` to ease the
installation of the hooks.