### PR TITLE
qa: fix F401 (unused import)

### DIFF
--- a/vint/ast/plugin/scope_plugin/__init__.py
+++ b/vint/ast/plugin/scope_plugin/__init__.py
@@ -9,7 +9,6 @@ from vint.ast.plugin.scope_plugin.reference_reachability_tester import (
 from vint.ast.plugin.scope_plugin.scope_detector import (
     ScopeVisibility as _ScopeVisibility,
     ExplicityOfScopeVisibility as _ExplicityOfScopeVisibility,
-    detect_possible_scope_visibility as _detect_possible_scope_visibility,
 )
 from vint.ast.plugin.scope_plugin.identifier_attribute import (
     is_autoload_identifier as _is_autoload_identifier,

--- a/vint/compat/itertools/__init__.py
+++ b/vint/compat/itertools/__init__.py
@@ -2,4 +2,4 @@ try:
     # 3.0 and later
     from itertools import zip_longest
 except ImportError:
-    from itertools import izip_longest as zip_longest
+    from itertools import izip_longest as zip_longest  # noqa: F401

--- a/vint/compat/unittest/__init__.py
+++ b/vint/compat/unittest/__init__.py
@@ -3,4 +3,4 @@ try:
     import unittest.mock as mock
 except ImportError:
     # You need to install 'mock' package before running
-    import mock
+    import mock  # noqa: F401

--- a/vint/linting/cli.py
+++ b/vint/linting/cli.py
@@ -2,7 +2,6 @@ from typing import Dict, Any, List  # noqa: F401
 import sys
 from argparse import ArgumentParser
 from pathlib import Path
-import pkg_resources
 import logging
 
 from vint.linting.linter import Linter

--- a/vint/linting/env.py
+++ b/vint/linting/env.py
@@ -1,4 +1,3 @@
-import sys
 import os
 import os.path
 from pathlib import Path

--- a/vint/linting/policy_set.py
+++ b/vint/linting/policy_set.py
@@ -1,6 +1,5 @@
 import logging
 from vint.linting.level import is_level_enabled
-import vint.linting.policy_registry as policy_registry
 
 
 class PolicySet(object):


### PR DESCRIPTION
Not importing `pkg_resources` should be beneficial with regard to
startup performance.