### PR TITLE
Policy: double quote: allow if dollar in string

### DIFF
--- a/vint/linting/policy/prohibit_unnecessary_double_quote.py
+++ b/vint/linting/policy/prohibit_unnecessary_double_quote.py
@@ -11,6 +11,7 @@ from vint.linting.policy_registry import register_policy
 # see `:help expr-string`
 _special_char_matcher = re.compile(
     r'(\'|'  # allow single quote
+    r'\$|'  # allow dollar
     r'\\('  # prefix back slash
     r'(?P<octal>[0-7]{1,3})'
     r'|(?P<hexadecimal>[xX][0-9a-fA-F]{1,2})'


### PR DESCRIPTION
One line to allow double quotes if there is a dollar in the string.
As example from my vimrc: 
```vim
let $h = expand($HOME)
let $w = expand("$h/wiki/wiki") | let $wiki = $w
```
Cleaner than `$h . '/wiki/wiki'` in my opignon