### PR TITLE
Fix message ("Unused variable" -> "Unused function" for function identifier)

### DIFF
--- a/vint/linting/policy/prohibit_unused_variable.py
+++ b/vint/linting/policy/prohibit_unused_variable.py
@@ -55,5 +55,9 @@ class ProhibitUnusedVariable(AbstractPolicy):
                 ))
                 return True
 
-        self.description = 'Unused variable: {var_name}'.format(var_name=identifier_value)
+        if scope_plugin.is_function_identifier(identifier):
+            node_type = 'function'
+        else:
+            node_type = 'variable'
+        self.description = 'Unused {node_type}: {var_name}'.format(node_type = node_type, var_name=identifier_value)
         return False


### PR DESCRIPTION
Fixed message for function identifer.

## Sample script

```vim
function! s:foo()
endfunction
```

## Before

```
vint test.vim 
test.vim:1:11: Unused variable: s:foo (see :help E738)
```

## After

```
vint test.vim 
test.vim:1:11: Unused function: s:foo (see :help E738)
```