### PR TITLE
Fix None access exception

### DIFF
--- a/vint/linting/config/config_container.py
+++ b/vint/linting/config/config_container.py
@@ -7,6 +7,8 @@ def merge_dict_deeply(posterior, prior):
     # type: (Dict[str, Any], Dict[str, Any]) -> Dict[str, Any]
     tmp = {}
 
+    if posterior is None:
+        posterior = {}
     for key in set(posterior.keys()) | set(prior.keys()):
         if key in prior:
             if isinstance(prior[key], dict):


### PR DESCRIPTION
When empty entry in config like this:

```
policies:
```

vint always raises an exception.

```
AttributeError: 'NoneType' object has no attribute 'keys'
```