### PR TITLE
Drop support for Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,6 @@ jobs:
     - name: Python 3.5
       python: "3.5"
       env: TOXENV=py35-cov
-    - name: Python 3.4
-      python: "3.4"
-      env: TOXENV=py34-cov
 
 install:
   - pip install tox

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,10 @@ setup(
         'Topic :: Text Editors',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
     entry_points={


### PR DESCRIPTION
It fails to install PyYAML on Travis:

> Collecting PyYAML>=3.11 (from vim-vint==0.3.21.dev53+g930a103)
>   Downloading https://files.pythonhosted.org/packages/3d/d9/ea9816aea31beeadccd03f1f8b625ecf8f645bd66744484d162d84803ce5/PyYAML-5.3.tar.gz (268kB)
> ERROR: PyYAML requires Python '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*' but the running Python is 3.4.8