### PR TITLE
Fix tox.ini for tox v4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,8 @@ envlist = py27, py38
 setenv =
   PYTHONDONTWRITEBYTECODE=1
   cov: PYTEST_ADDOPTS=--cov --cov-report=term-missing:skip-covered {env:PYTEST_ADDOPTS:}
-passenv = PYTEST_ADDOPTS TERM
+passenv =
+  PYTEST_ADDOPTS
+  TERM
 extras = testing
 commands = pytest {posargs:}


### PR DESCRIPTION
Fixes [tox error](https://github.com/Vimjas/vint/actions/runs/7172972642/job/19538410089) that [space-separated variables are not allowed in tox 4](https://github.com/tox-dev/tox/issues/2615)

> py310-cov: failed with pass_env values cannot contain whitespace, use comma to have multiple values in a single line, invalid values found 'PYTEST_ADDOPTS TERM'
>   py310-cov: FAIL code 1 (0.00 seconds)
>   evaluation failed :( (1.00 seconds)
> Error: Process completed with exit code 1.